### PR TITLE
Fix wiring of dotnet-morphir (was mising EntryPoint attribute)

### DIFF
--- a/src/dotnet-morphir/Program.fs
+++ b/src/dotnet-morphir/Program.fs
@@ -3,4 +3,5 @@
 open Morphir.Tools
 open Morphir.Tools.CommandLine
 
+[<EntryPoint>]
 let main (args: string[]) = CommandLine.run args


### PR DESCRIPTION
Fix wiring of dotnet-morphir (was mising EntryPoint attribute)