### PR TITLE
Fix docs workflow to only deploy on main branch and tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,15 @@
 name: "Deploy Docs To GitHub Pages"
 
 on:
-  pull_request:
-    # Deploy on PRs to main branch only
+  push:
     branches:
       - main
+    tags:
+      - 'v*'
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -80,8 +82,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # Deploy on PRs to main branch only
-    if: github.event.pull_request.base.ref == 'main'
+    # Deploy on pushes to main (including tags) or manual workflow dispatch
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Remove PR deployment triggers to prevent workflow failures
- Configure deployment only for pushes to main branch
- Add support for tag-based deployments (v* pattern)
- Keep manual workflow_dispatch trigger
- Simplify deploy job conditions

## Changes
The docs workflow was failing on PRs because it attempted to deploy on every PR. This PR updates the workflow to only deploy when:
- Changes are pushed to the main branch
- A version tag (v*) is created
- Manually triggered via workflow_dispatch

This should resolve the failing deployments while maintaining the ability to deploy docs when needed.