### PR TITLE
feat: enable Dependabot support for .NET, npm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+# Dependabot configuration for morphir-dotnet
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # .NET NuGet dependencies
+  # Monitors centralized package management in Directory.Packages.props
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Keep major updates separate for review
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+      - "dotnet"
+
+  # NPM dependencies for Hugo documentation
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "documentation"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary

Enables Dependabot version updates for all dependency ecosystems in the morphir-dotnet repository.

## Changes

- Add `.github/dependabot.yml` configuration file
- Configure daily NuGet (.NET) dependency monitoring
- Configure weekly npm dependency monitoring for documentation tooling
- Configure weekly GitHub Actions version monitoring

## Dependabot Configuration

### NuGet (.NET Dependencies)
- **Ecosystem**: `nuget` - 39 packages in `Directory.Packages.props`
- **Schedule**: Daily at 03:00 UTC
- **Strategy**: Group minor/patch updates, separate major updates for review
- **PR Limit**: 10 open PRs
- **Labels**: `dependencies`, `dotnet`

### NPM (Documentation Dependencies)
- **Ecosystem**: `npm` - 3 packages in `docs/`
- **Schedule**: Weekly (Mondays at 03:00 UTC)
- **Strategy**: Group minor/patch updates
- **PR Limit**: 5 open PRs
- **Labels**: `dependencies`, `documentation`

### GitHub Actions
- **Ecosystem**: `github-actions` - 3 workflow files
- **Schedule**: Weekly (Mondays at 03:00 UTC)
- **Strategy**: Group all action updates
- **PR Limit**: 5 open PRs
- **Labels**: `dependencies`, `ci`

## Benefits

- Automated dependency updates for security and bug fixes
- Reduces manual dependency management overhead
- Groups related updates to minimize PR noise
- Respects Central Package Management (CPM) for .NET
- Follows Conventional Commits format (`chore(deps):`)
- Will immediately identify outdated GitHub Actions (e.g., v3 → v4 in deployment.yml)

## Test Plan

- [x] Configuration file follows Dependabot schema
- [x] Commit passes Husky pre-commit format check
- [ ] Verify Dependabot runs successfully after merge
- [ ] Review initial PRs created by Dependabot

## Related

- Addresses previous Dependabot activity (PRs #144, #141) by adding formal configuration
- Aligns with project's dependency minimization policy (AGENTS.md Section 10)