### PR TITLE
Use NUGET_KEY instead of NUGET_TOKEN

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,7 +21,7 @@ on:
 env:
     CONFIGURATION: ${{ github.event.inputs.configuration || 'Release' }}
     RELEASE_VERSION: ${{ github.event.inputs.release-version }}
-    NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+    NUGET_TOKEN: ${{ secrets.NUGET_KEY }}
     SKIP_GIT_RELEASE: ${{ github.event.inputs.skip-git-release }}
     GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
Updates the deployment workflow to use the NUGET_KEY secret instead of NUGET_TOKEN.

NUGET_KEY was last updated on 2025-01-07, while NUGET_TOKEN was last updated on 2023-03-17 and is likely expired, causing 403 authentication errors.