### PR TITLE
fix: merge artifacts in E2E test download step

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -126,6 +126,8 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   path: ./artifacts/single-file
+                  pattern: morphir-*
+                  merge-multiple: true
                   
             - name: Run E2E tests
               run: just test-e2e EXECUTABLE_TYPE=trimmed


### PR DESCRIPTION
Fixes the E2E test failure in the deployment workflow.

The download-artifact action was creating nested directories (morphir-linux-x64/linux-x64/morphir) but the ExecutableLocator expects a flat structure (artifacts/single-file/linux-x64/morphir).

Using `merge-multiple: true` flattens the artifact structure to match the expected paths.