### PR TITLE
fix: pass EXECUTABLE_TYPE as argument to test-e2e

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -130,7 +130,7 @@ jobs:
                   merge-multiple: true
                   
             - name: Run E2E tests
-              run: just test-e2e EXECUTABLE_TYPE=trimmed
+              run: just test-e2e trimmed
               env:
                   CONFIGURATION: ${{ env.CONFIGURATION }}
 


### PR DESCRIPTION
The test-e2e script reads EXECUTABLE_TYPE from the first argument, not from environment variables. The workflow was setting it as an environment variable which caused the script to default to 'all' and try to build AOT executables.

This fix passes 'trimmed' as an argument to the script so it correctly tests only trimmed executables.