### PR TITLE
fix: update install scripts to use dotnet-morphir and download from GitHub releases

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -9,6 +9,7 @@ VERSION="${1:-}"
 INSTALL_DIR="${MORPHIR_INSTALL_DIR:-$HOME/.local/bin}"
 NUGET_PACKAGE="Morphir"
 NUGET_SOURCE="https://api.nuget.org/v3/index.json"
+TOOL_COMMAND="dotnet-morphir"
 
 # Detect architecture
 ARCH=$(uname -m)
@@ -39,22 +40,24 @@ if command -v dotnet &> /dev/null; then
         dotnet tool update --global "$NUGET_PACKAGE" --add-source "$NUGET_SOURCE"
     fi
     
-    echo "✓ Morphir CLI installed successfully"
+    echo "✓ Morphir CLI installed successfully as $TOOL_COMMAND"
     echo ""
-    echo "To use morphir, ensure ~/.dotnet/tools is in your PATH:"
+    echo "To use morphir, run: $TOOL_COMMAND"
+    echo ""
+    echo "Ensure ~/.dotnet/tools is in your PATH:"
     echo "  export PATH=\"\$PATH:\$HOME/.dotnet/tools\""
     echo ""
     echo "Or add it permanently to your shell profile (~/.bashrc or ~/.zshrc)"
 else
-    echo "dotnet not found. Installing platform-specific executable..."
+    echo "dotnet not found. Installing standalone executable from GitHub releases..."
     
     # Create install directory
     mkdir -p "$INSTALL_DIR"
     
     # Determine version to download
     if [ -z "$VERSION" ]; then
-        echo "Fetching latest version from NuGet..."
-        VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/$NUGET_PACKAGE/index.json" | grep -oP '"versions":\["[^"]*"' | grep -oP '"[0-9]+\.[0-9]+\.[0-9]+[^"]*"' | tail -1 | tr -d '"')
+        echo "Fetching latest version from GitHub releases..."
+        VERSION=$(curl -s "https://api.github.com/repos/finos/morphir-dotnet/releases/latest" | grep -oP '"tag_name":\s*"v?\K[^"]+' | head -1)
         if [ -z "$VERSION" ]; then
             echo "Error: Could not determine latest version"
             exit 1
@@ -62,54 +65,46 @@ else
         echo "Latest version: $VERSION"
     fi
     
-    # Download NuGet package
-    PACKAGE_URL="https://www.nuget.org/api/v2/package/$NUGET_PACKAGE/$VERSION"
+    # Construct download URL for the executable
+    RELEASE_TAG="v${VERSION#v}"  # Ensure v prefix
+    ASSET_NAME="morphir-${RID}"
+    DOWNLOAD_URL="https://github.com/finos/morphir-dotnet/releases/download/$RELEASE_TAG/$ASSET_NAME"
+    
+    echo "Downloading Morphir $VERSION for $RID..."
     TEMP_DIR=$(mktemp -d)
-    PACKAGE_FILE="$TEMP_DIR/morphir.nupkg"
+    EXE_FILE="$TEMP_DIR/morphir"
     
-    echo "Downloading Morphir $VERSION..."
-    curl -L -o "$PACKAGE_FILE" "$PACKAGE_URL" || {
-        echo "Error: Failed to download package"
+    # Download the executable
+    if curl -L -f -o "$EXE_FILE" "$DOWNLOAD_URL"; then
+        chmod +x "$EXE_FILE"
+        cp "$EXE_FILE" "$INSTALL_DIR/morphir"
         rm -rf "$TEMP_DIR"
-        exit 1
-    }
-    
-    # Extract package (NuGet packages are ZIP files)
-    echo "Extracting package..."
-    unzip -q "$PACKAGE_FILE" -d "$TEMP_DIR" || {
-        echo "Error: Failed to extract package (unzip required)"
-        rm -rf "$TEMP_DIR"
-        exit 1
-    }
-    
-    # Find and copy the platform-specific executable
-    EXE_SOURCE="$TEMP_DIR/tools/net10.0/$RID/morphir"
-    if [ ! -f "$EXE_SOURCE" ]; then
-        echo "Error: Platform-specific executable not found for $RID"
-        echo "Available platforms:"
-        find "$TEMP_DIR/tools/net10.0" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+        
+        echo "✓ Morphir CLI installed to $INSTALL_DIR/morphir"
+        echo ""
+        echo "To use morphir, ensure $INSTALL_DIR is in your PATH:"
+        echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+        echo ""
+        echo "Or add it permanently to your shell profile (~/.bashrc or ~/.zshrc):"
+        echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.bashrc"
+        echo "  source ~/.bashrc"
+    else
+        echo "Error: Failed to download executable for $RID"
+        echo ""
+        echo "Please download manually from:"
+        echo "  https://github.com/finos/morphir-dotnet/releases/tag/$RELEASE_TAG"
+        echo ""
+        echo "Or install .NET runtime and use: dotnet tool install --global Morphir"
         rm -rf "$TEMP_DIR"
         exit 1
     fi
-    
-    # Copy executable to install directory
-    cp "$EXE_SOURCE" "$INSTALL_DIR/morphir"
-    chmod +x "$INSTALL_DIR/morphir"
-    
-    # Cleanup
-    rm -rf "$TEMP_DIR"
-    
-    echo "✓ Morphir CLI installed to $INSTALL_DIR/morphir"
-    echo ""
-    echo "To use morphir, ensure $INSTALL_DIR is in your PATH:"
-    echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
-    echo ""
-    echo "Or add it permanently to your shell profile (~/.bashrc or ~/.zshrc):"
-    echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.bashrc"
-    echo "  source ~/.bashrc"
 fi
 
 echo ""
 echo "Verify installation:"
-echo "  morphir --version"
+if command -v dotnet &> /dev/null; then
+    echo "  $TOOL_COMMAND --version"
+else
+    echo "  morphir --version"
+fi
 

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -9,6 +9,7 @@ VERSION="${1:-}"
 INSTALL_DIR="${MORPHIR_INSTALL_DIR:-/usr/local/bin}"
 NUGET_PACKAGE="Morphir"
 NUGET_SOURCE="https://api.nuget.org/v3/index.json"
+TOOL_COMMAND="dotnet-morphir"
 
 # Detect architecture
 ARCH=$(uname -m)
@@ -39,22 +40,24 @@ if command -v dotnet &> /dev/null; then
         dotnet tool update --global "$NUGET_PACKAGE" --add-source "$NUGET_SOURCE"
     fi
     
-    echo "✓ Morphir CLI installed successfully"
+    echo "✓ Morphir CLI installed successfully as $TOOL_COMMAND"
     echo ""
-    echo "To use morphir, ensure ~/.dotnet/tools is in your PATH:"
+    echo "To use morphir, run: $TOOL_COMMAND"
+    echo ""
+    echo "Ensure ~/.dotnet/tools is in your PATH:"
     echo "  export PATH=\"\$PATH:\$HOME/.dotnet/tools\""
     echo ""
     echo "Or add it permanently to your shell profile (~/.zshrc or ~/.bash_profile)"
 else
-    echo "dotnet not found. Installing platform-specific executable..."
+    echo "dotnet not found. Installing standalone executable from GitHub releases..."
     
     # Create install directory
     mkdir -p "$INSTALL_DIR"
     
     # Determine version to download
     if [ -z "$VERSION" ]; then
-        echo "Fetching latest version from NuGet..."
-        VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/$NUGET_PACKAGE/index.json" | grep -oP '"versions":\["[^"]*"' | grep -oP '"[0-9]+\.[0-9]+\.[0-9]+[^"]*"' | tail -1 | tr -d '"')
+        echo "Fetching latest version from GitHub releases..."
+        VERSION=$(curl -s "https://api.github.com/repos/finos/morphir-dotnet/releases/latest" | grep -oP '"tag_name":\s*"v?\K[^"]+' | head -1)
         if [ -z "$VERSION" ]; then
             echo "Error: Could not determine latest version"
             exit 1
@@ -62,54 +65,46 @@ else
         echo "Latest version: $VERSION"
     fi
     
-    # Download NuGet package
-    PACKAGE_URL="https://www.nuget.org/api/v2/package/$NUGET_PACKAGE/$VERSION"
+    # Construct download URL for the executable
+    RELEASE_TAG="v${VERSION#v}"  # Ensure v prefix
+    ASSET_NAME="morphir-${RID}"
+    DOWNLOAD_URL="https://github.com/finos/morphir-dotnet/releases/download/$RELEASE_TAG/$ASSET_NAME"
+    
+    echo "Downloading Morphir $VERSION for $RID..."
     TEMP_DIR=$(mktemp -d)
-    PACKAGE_FILE="$TEMP_DIR/morphir.nupkg"
+    EXE_FILE="$TEMP_DIR/morphir"
     
-    echo "Downloading Morphir $VERSION..."
-    curl -L -o "$PACKAGE_FILE" "$PACKAGE_URL" || {
-        echo "Error: Failed to download package"
+    # Download the executable
+    if curl -L -f -o "$EXE_FILE" "$DOWNLOAD_URL"; then
+        chmod +x "$EXE_FILE"
+        cp "$EXE_FILE" "$INSTALL_DIR/morphir"
         rm -rf "$TEMP_DIR"
-        exit 1
-    }
-    
-    # Extract package (NuGet packages are ZIP files)
-    echo "Extracting package..."
-    unzip -q "$PACKAGE_FILE" -d "$TEMP_DIR" || {
-        echo "Error: Failed to extract package (unzip required)"
-        rm -rf "$TEMP_DIR"
-        exit 1
-    }
-    
-    # Find and copy the platform-specific executable
-    EXE_SOURCE="$TEMP_DIR/tools/net10.0/$RID/morphir"
-    if [ ! -f "$EXE_SOURCE" ]; then
-        echo "Error: Platform-specific executable not found for $RID"
-        echo "Available platforms:"
-        find "$TEMP_DIR/tools/net10.0" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+        
+        echo "✓ Morphir CLI installed to $INSTALL_DIR/morphir"
+        echo ""
+        echo "To use morphir, ensure $INSTALL_DIR is in your PATH:"
+        echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+        echo ""
+        echo "Or add it permanently to your shell profile (~/.zshrc or ~/.bash_profile):"
+        echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.zshrc"
+        echo "  source ~/.zshrc"
+    else
+        echo "Error: Failed to download executable for $RID"
+        echo ""
+        echo "Please download manually from:"
+        echo "  https://github.com/finos/morphir-dotnet/releases/tag/$RELEASE_TAG"
+        echo ""
+        echo "Or install .NET runtime and use: dotnet tool install --global Morphir"
         rm -rf "$TEMP_DIR"
         exit 1
     fi
-    
-    # Copy executable to install directory
-    cp "$EXE_SOURCE" "$INSTALL_DIR/morphir"
-    chmod +x "$INSTALL_DIR/morphir"
-    
-    # Cleanup
-    rm -rf "$TEMP_DIR"
-    
-    echo "✓ Morphir CLI installed to $INSTALL_DIR/morphir"
-    echo ""
-    echo "To use morphir, ensure $INSTALL_DIR is in your PATH:"
-    echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
-    echo ""
-    echo "Or add it permanently to your shell profile (~/.zshrc or ~/.bash_profile):"
-    echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.zshrc"
-    echo "  source ~/.zshrc"
 fi
 
 echo ""
 echo "Verify installation:"
-echo "  morphir --version"
+if command -v dotnet &> /dev/null; then
+    echo "  $TOOL_COMMAND --version"
+else
+    echo "  morphir --version"
+fi
 

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -10,6 +10,7 @@ $ErrorActionPreference = "Stop"
 
 $NuGetPackage = "Morphir"
 $NuGetSource = "https://api.nuget.org/v3/index.json"
+$ToolCommand = "dotnet-morphir"
 $InstallDir = if ($env:MORPHIR_INSTALL_DIR) { $env:MORPHIR_INSTALL_DIR } else { "$env:LOCALAPPDATA\morphir\bin" }
 
 # Detect architecture
@@ -40,22 +41,24 @@ if ($dotnetPath) {
         }
     }
     
-    Write-Host "✓ Morphir CLI installed successfully" -ForegroundColor Green
+    Write-Host "✓ Morphir CLI installed successfully as $ToolCommand" -ForegroundColor Green
     Write-Host ""
-    Write-Host "To use morphir, ensure %USERPROFILE%\.dotnet\tools is in your PATH"
+    Write-Host "To use morphir, run: $ToolCommand"
+    Write-Host ""
+    Write-Host "Ensure %USERPROFILE%\.dotnet\tools is in your PATH"
     Write-Host "Or restart your terminal/PowerShell session"
 } else {
-    Write-Host "dotnet not found. Installing platform-specific executable..."
+    Write-Host "dotnet not found. Installing standalone executable from GitHub releases..."
     
     # Create install directory
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
     
     # Determine version to download
     if (-not $Version) {
-        Write-Host "Fetching latest version from NuGet..."
+        Write-Host "Fetching latest version from GitHub releases..."
         try {
-            $indexResponse = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$NuGetPackage/index.json"
-            $Version = $indexResponse.versions | Select-Object -Last 1
+            $releaseResponse = Invoke-RestMethod -Uri "https://api.github.com/repos/finos/morphir-dotnet/releases/latest"
+            $Version = $releaseResponse.tag_name -replace '^v', ''
             Write-Host "Latest version: $Version"
         } catch {
             Write-Host "Error: Could not determine latest version" -ForegroundColor Red
@@ -64,57 +67,44 @@ if ($dotnetPath) {
         }
     }
     
-    # Download NuGet package
-    $PackageUrl = "https://www.nuget.org/api/v2/package/$NuGetPackage/$Version"
+    # Construct download URL for the executable
+    $ReleaseTag = "v$($Version -replace '^v', '')"
+    $AssetName = "morphir-$RID.exe"
+    $DownloadUrl = "https://github.com/finos/morphir-dotnet/releases/download/$ReleaseTag/$AssetName"
+    
+    Write-Host "Downloading Morphir $Version for $RID..."
     $TempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
-    $PackageFile = Join-Path $TempDir "morphir.nupkg"
+    $ExeFile = Join-Path $TempDir "morphir.exe"
     
-    Write-Host "Downloading Morphir $Version..."
     try {
-        Invoke-WebRequest -Uri $PackageUrl -OutFile $PackageFile -UseBasicParsing
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $ExeFile -UseBasicParsing
+        Copy-Item -Path $ExeFile -Destination (Join-Path $InstallDir "morphir.exe") -Force
+        Remove-Item -Recurse -Force $TempDir
+        
+        Write-Host "✓ Morphir CLI installed to $InstallDir\morphir.exe" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "To use morphir, add $InstallDir to your PATH:"
+        Write-Host "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$InstallDir', 'User')"
+        Write-Host ""
+        Write-Host "Or manually add it via System Properties > Environment Variables"
     } catch {
-        Write-Host "Error: Failed to download package" -ForegroundColor Red
+        Write-Host "Error: Failed to download executable for $RID" -ForegroundColor Red
         Write-Host $_.Exception.Message
+        Write-Host ""
+        Write-Host "Please download manually from:"
+        Write-Host "  https://github.com/finos/morphir-dotnet/releases/tag/$ReleaseTag"
+        Write-Host ""
+        Write-Host "Or install .NET runtime and use: dotnet tool install --global Morphir"
         Remove-Item -Recurse -Force $TempDir
         exit 1
     }
-    
-    # Extract package (NuGet packages are ZIP files)
-    Write-Host "Extracting package..."
-    try {
-        Expand-Archive -Path $PackageFile -DestinationPath $TempDir -Force
-    } catch {
-        Write-Host "Error: Failed to extract package" -ForegroundColor Red
-        Write-Host $_.Exception.Message
-        Remove-Item -Recurse -Force $TempDir
-        exit 1
-    }
-    
-    # Find and copy the platform-specific executable
-    $ExeSource = Join-Path $TempDir "tools\net10.0\$RID\morphir.exe"
-    if (-not (Test-Path $ExeSource)) {
-        Write-Host "Error: Platform-specific executable not found for $RID" -ForegroundColor Red
-        Write-Host "Available platforms:"
-        Get-ChildItem (Join-Path $TempDir "tools\net10.0") -Directory | ForEach-Object { Write-Host "  $($_.Name)" }
-        Remove-Item -Recurse -Force $TempDir
-        exit 1
-    }
-    
-    # Copy executable to install directory
-    Copy-Item -Path $ExeSource -Destination (Join-Path $InstallDir "morphir.exe") -Force
-    
-    # Cleanup
-    Remove-Item -Recurse -Force $TempDir
-    
-    Write-Host "✓ Morphir CLI installed to $InstallDir\morphir.exe" -ForegroundColor Green
-    Write-Host ""
-    Write-Host "To use morphir, add $InstallDir to your PATH:"
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$InstallDir', 'User')"
-    Write-Host ""
-    Write-Host "Or manually add it via System Properties > Environment Variables"
 }
 
 Write-Host ""
 Write-Host "Verify installation:"
-Write-Host "  morphir --version"
+if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+    Write-Host "  $ToolCommand --version"
+} else {
+    Write-Host "  morphir --version"
+}
 


### PR DESCRIPTION
## Changes

- Updated all install scripts to reference `dotnet-morphir` command name (was missing)
- Fixed fallback path to download standalone executables from GitHub releases instead of extracting from NuGet package (which no longer contains platform-specific executables)
- Updated verification instructions to use correct command name

## Testing

- ✅ Dotnet tool installation tested locally and works correctly
- ✅ Install scripts updated to handle both dotnet tool and standalone executable paths

This PR should be merged quickly as the deployment workflow has already been triggered and will need these changes for the install scripts to work correctly with the new tool package structure.