### PR TITLE
fix: set executable permissions for E2E test artifacts

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -142,6 +142,18 @@ jobs:
                   echo "Looking for linux-x64 executable:"
                   ls -la ./artifacts/single-file/linux-x64/ 2>&1 || echo "Directory not found"
                   
+            - name: Set executable permissions
+              run: |
+                  # Make all executables executable (for flattened structure)
+                  find ./artifacts/single-file -type f -name "morphir" -exec chmod +x {} \;
+                  # Also check RID-specific directories (if structure is preserved)
+                  find ./artifacts/single-file -type d -mindepth 1 -maxdepth 1 | while read dir; do
+                      if [ -f "$dir/morphir" ]; then
+                          chmod +x "$dir/morphir"
+                      fi
+                  done
+                  echo "Executable permissions set"
+                  
             - name: Run E2E tests
               run: just test-e2e trimmed
               env:


### PR DESCRIPTION
## Problem

E2E tests are failing with `Permission denied` errors when trying to execute the Morphir executable:
```
Win32Exception: An error occurred trying to start process '/home/runner/work/morphir-dotnet/morphir-dotnet/artifacts/single-file/morphir' with working directory '/home/runner/work/morphir-dotnet/morphir-dotnet/tests/Morphir.E2E.Tests/bin/Release/net10.0'. Permission denied
```

This happens because when artifacts are downloaded with `merge-multiple: true`, the executable files lose their execute permissions.

## Solution

Added a step to set execute permissions on all `morphir` executables after downloading artifacts. The step handles both:
1. Flattened structure (when `merge-multiple: true` flattens artifacts)
2. RID-specific directories (if structure is preserved)

## Testing

- ✅ Handles both flattened and RID-specific artifact structures
- ✅ Sets execute permissions on all morphir executables
- ✅ Fixes the Permission denied errors in E2E tests