### PR TITLE
chore: update changelog for v0.2.0-alpha-009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0-alpha-004] - 2025-12-17
+## [0.2.0-alpha-009] - 2025-12-17
 
 ### Fixed
 - NuGet packages now include LICENSE file and correct metadata (repository URL, project URL)
@@ -50,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local publishing workflow for testing packages
 - KeepAChangelog integration for automatic versioning
 
-[Unreleased]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-004...HEAD
-[0.2.0-alpha-004]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-003...v0.2.0-alpha-004
+[Unreleased]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-009...HEAD
+[0.2.0-alpha-009]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-008...v0.2.0-alpha-009
 [0.2.0-alpha-003]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-002...v0.2.0-alpha-003
 [0.2.0-alpha-002]: https://github.com/finos/morphir-dotnet/compare/v0.2.0-alpha-001...v0.2.0-alpha-002
 [0.2.0-alpha-001]: https://github.com/finos/morphir-dotnet/releases/tag/v0.2.0-alpha-001


### PR DESCRIPTION
Updates CHANGELOG.md with new version entry for v0.2.0-alpha-009.

**Changes:**
- Added v0.2.0-alpha-009 entry with fix for NuGet package metadata (LICENSE file, repository URL, project URL)
- Updated version links to reference v0.2.0-alpha-008 as the previous version

This PR should be merged before triggering the deployment workflow.