### PR TITLE
fix: correct E2E test script execution in Nuke build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -381,7 +381,7 @@ class Build : NukeBuild
         .Executes(() =>
         {
             Serilog.Log.Information($"Running E2E tests for executable type: {ExecutableType}");
-            var exitCode = RunCommand("dotnet", "run", "--project",
+            var exitCode = RunCommand("dotnet",
                 ScriptsDirectory / "run-e2e-tests.cs", ExecutableType, Configuration);
 
             if (exitCode != 0)


### PR DESCRIPTION
## Summary

Fixes the TestE2E target in the Nuke build which was failing in the deployment workflow with error:

```
error MSB4025: The project file could not be loaded. Data at the root level is invalid. Line 1, position 1.
```

## Root Cause

The TestE2E target was incorrectly using `dotnet run --project` to execute the C# script:

```csharp
RunCommand("dotnet", "run", "--project", ScriptsDirectory / "run-e2e-tests.cs", ...)
```

But `--project` expects a .csproj file, not a C# top-level script (.cs file).

## Solution

Changed to execute the script directly without `--project` flag:

```csharp
RunCommand("dotnet", ScriptsDirectory / "run-e2e-tests.cs", ExecutableType, Configuration)
```

C# top-level scripts with `#!/usr/bin/env dotnet run` shebang should be executed as `dotnet <script.cs>`, not `dotnet run --project <script.cs>`.

## Testing

- [x] Local pre-commit hook passed
- [ ] CI tests will verify the fix

## Related

This fixes the deployment workflow failure encountered in PR #195 testing.

🤖 Generated with Claude Code