### PR TITLE
fix: output only version number for --version flag

### DIFF
--- a/src/Morphir/Morphir.csproj
+++ b/src/Morphir/Morphir.csproj
@@ -7,6 +7,29 @@
         <Nullable>enable</Nullable>
         <AssemblyName>morphir</AssemblyName>
     </PropertyGroup>
+
+    <!-- Generate version constant file at build time -->
+    <Target Name="GenerateVersionFile" BeforeTargets="CoreCompile">
+        <PropertyGroup>
+            <!-- Use AssemblyInformationalVersion if set, otherwise Version, otherwise default -->
+            <MorphirVersionString Condition="'$(InformationalVersion)' != ''">$(InformationalVersion)</MorphirVersionString>
+            <MorphirVersionString Condition="'$(MorphirVersionString)' == '' AND '$(Version)' != ''">$(Version)</MorphirVersionString>
+            <MorphirVersionString Condition="'$(MorphirVersionString)' == ''">0.0.0-dev</MorphirVersionString>
+            <VersionFileContent>
+// &lt;auto-generated/&gt;
+namespace Morphir%3B
+
+internal static class VersionInfo
+{
+    public const string Version = "$(MorphirVersionString)"%3B
+}
+            </VersionFileContent>
+        </PropertyGroup>
+        <WriteLinesToFile File="$(IntermediateOutputPath)VersionInfo.g.cs" Lines="$(VersionFileContent)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+        <ItemGroup>
+            <Compile Include="$(IntermediateOutputPath)VersionInfo.g.cs" />
+        </ItemGroup>
+    </Target>
     <!-- AOT and trimming settings are set via command-line arguments during publish -->
     <!-- This prevents them from affecting dotnet run/build operations -->
     <!-- See justfile publish-executable task for publish-time settings -->

--- a/src/Morphir/Program.cs
+++ b/src/Morphir/Program.cs
@@ -24,6 +24,13 @@ internal static class Program
         // Set console encoding to UTF-8 to support Unicode characters (✓, ✗)
         Console.OutputEncoding = System.Text.Encoding.UTF8;
 
+        // Handle --version flag explicitly to output only the version string
+        if (args.Length == 1 && (args[0] == "--version" || args[0] == "-v"))
+        {
+            Console.WriteLine(VersionInfo.Version);
+            return 0;
+        }
+
         Option<FileInfo> currentDirectoryOption = new("-C")
         {
             Description = "Override the current directory",


### PR DESCRIPTION
## Summary
Fixes the E2E test failures in the deployment workflow by making the CLI's `--version` flag output only the semantic version number instead of the full help text.

## Problem
The deployment workflow was failing E2E tests on multiple platforms because:
- Running `morphir --version` output the full help text including description, usage, and options
- E2E tests expected just the semantic version matching the pattern `^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$`
- This caused test failures on linux-arm64, osx-x64, osx-arm64, and win-x64

## Solution
1. **Compile-time version generation**: Added MSBuild target `GenerateVersionFile` that creates `VersionInfo.g.cs` with a compile-time constant
2. **Explicit --version handling**: Updated `Program.cs` to intercept `--version` flag before System.CommandLine processes it
3. **No reflection**: Uses compile-time code generation instead of runtime reflection for better AOT and trimming compatibility

Version priority order:
1. `InformationalVersion` property (set during publish)
2. `Version` property (from KeepAChangelog or build parameter)
3. Default: `"0.0.0-dev"`

## Testing
- ✅ Local E2E tests pass: `./build.sh --target TestE2E --executable-type trimmed`
- ✅ Version output validated: `morphir --version` outputs `0.2.0-alpha-010+{git-hash}`
- ✅ Matches semver pattern required by E2E tests
- ✅ Pre-commit hooks pass (format check)

## Related
- Follows up on #195 (Nuke build migration)
- Follows up on #196 (E2E test script execution fix)
- Completes the deployment workflow validation

## Files Changed
- `src/Morphir/Morphir.csproj`: Added MSBuild target to generate VersionInfo.g.cs
- `src/Morphir/Program.cs`: Added explicit --version flag handler using compile-time constant