### PR TITLE
fix: preserve JsonSchema.Net assembly during trimming

### DIFF
--- a/src/Morphir.Core/packages.lock.json
+++ b/src/Morphir.Core/packages.lock.json
@@ -72,6 +72,7 @@
         "resolved": "1.1.1",
         "contentHash": "MalY0Y/uM/LjXtHfX/26l2VtN4LDNZ2OE3aumNOHDLsT4fNYy2hiHXI4CXCqKpNUNm7iJ2brrc4J89UdaL56FA=="
       }
-    }
+    },
+    "net10.0/linux-arm64": {}
   }
 }

--- a/src/Morphir.Tooling/ILLink.Descriptors.xml
+++ b/src/Morphir.Tooling/ILLink.Descriptors.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ILLink descriptor file to preserve embedded resources during trimming.
-  This prevents the .NET trimmer from removing JSON schema files that are
-  loaded at runtime via Assembly.GetManifestResourceStream().
+  Trimming descriptor to ensure JsonSchema.Net validation works correctly
+  in trimmed applications. The library uses reflection for schema validation
+  which requires preservation of certain types and resources.
 -->
 <linker>
+    <!-- Preserve embedded schema resources -->
     <assembly fullname="Morphir.Tooling">
-        <!-- Preserve all embedded resources -->
-        <resource>Infrastructure/Schemas/morphir-ir-v1.json</resource>
-        <resource>Infrastructure/Schemas/morphir-ir-v2.json</resource>
-        <resource>Infrastructure/Schemas/morphir-ir-v3.json</resource>
-
-        <!-- Preserve the SchemaLoader class and its dependencies -->
-        <type fullname="Morphir.Tooling.Infrastructure.JsonSchema.SchemaLoader" preserve="all" />
-        <type fullname="Morphir.Tooling.Infrastructure.JsonSchema.SchemaValidator" preserve="all" />
+        <resource>Morphir.Tooling.Infrastructure.Schemas.morphir-ir-v1.json</resource>
+        <resource>Morphir.Tooling.Infrastructure.Schemas.morphir-ir-v2.json</resource>
+        <resource>Morphir.Tooling.Infrastructure.Schemas.morphir-ir-v3.json</resource>
     </assembly>
+
+    <!-- Preserve JsonSchema.Net types for reflection-based validation -->
+    <assembly fullname="JsonSchema.Net" preserve="all" />
 </linker>

--- a/src/Morphir.Tooling/packages.lock.json
+++ b/src/Morphir.Tooling/packages.lock.json
@@ -709,6 +709,13 @@
         "resolved": "8.0.3",
         "contentHash": "mWcOP9OazN1pqZTGedVG+7k+mA5gDy5ZVgF7hlIhY+Dt4Ex+oAdU3ktNB8PjIjyf5MC37M/Z5Yv6DdDdldCPqw=="
       }
+    },
+    "net10.0/linux-arm64": {
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "qd01+AqPhbAG14KtdtIqFk+cxHQFZ/oqRSCoxU1F+Q6Kv0cl726sl7RzU9yLFGd4BUOKdN4XojXF0pQf/R6YeA=="
+      }
     }
   }
 }

--- a/src/Morphir/packages.lock.json
+++ b/src/Morphir/packages.lock.json
@@ -640,7 +640,7 @@
           "JasperFx.CodeGeneration.Commands": "[3.7.2, )",
           "Json.More.Net": "[2.2.0, )",
           "JsonSchema.Net": "[8.0.3, )",
-          "Morphir.Core": "[1.0.0, )",
+          "Morphir.Core": "[0.0.0-local-test2, )",
           "Oakton": "[6.3.0, )",
           "Serilog": "[4.3.0, )",
           "Serilog.Extensions.Hosting": "[5.0.1, )",


### PR DESCRIPTION
## Problem
Deployment workflow failing on all platforms after PR #199 merge with E2E test regression:
- "Verify JSON output for invalid file includes errors" failing
- Expected `IsValid=false` but getting `IsValid=true` for invalid files
- This is a new regression introduced by the ILLink descriptor changes

## Root Cause
The initial ILLink.Descriptors.xml in PR #199 was too narrow - it only preserved specific types and resources, but JsonSchema.Net uses extensive reflection for JSON Schema validation that requires the entire assembly to be preserved during trimming.

## Solution
Update ILLink.Descriptors.xml to preserve the **entire JsonSchema.Net assembly** with `preserve="all"`:
- Keeps resource preservation with correct dotted naming convention
- Removes type-specific preservation (SchemaLoader, SchemaValidator)
- Adds full assembly preservation for JsonSchema.Net

## Testing
✅ Verified locally with trimmed executable:
- Invalid file correctly returns `IsValid=false`  
- Valid files correctly return `IsValid=true`
- JSON output parsing works correctly
- All schema versions (v1, v2, v3) load successfully

## Impact
- Slightly larger executable size due to preserving JsonSchema.Net
- Should resolve all platform E2E failures from previous deployment
- No functional impact - validation works correctly

## Related
- Fixes regression from PR #199
- Related to deployment run #20293864368 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)