### PR TITLE
ci: remove osx-x64 from deployment matrix

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,8 +53,6 @@ jobs:
                       os: ubuntu-24.04-arm
                     - rid: win-x64
                       os: windows-latest
-                    - rid: osx-x64
-                      os: macos-15-intel
                     - rid: osx-arm64
                       os: macos-latest
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
Remove macOS Intel (osx-x64) platform from deployment workflow due to unrelated help command display issue.

## Problem
During deployment testing, macOS x64 builds are failing E2E tests with a platform-specific issue where the help command outputs version information instead of help text. This is a separate bug from the JsonSchema trimming fixes recently merged.

## Solution
Temporarily remove osx-x64 from the deployment matrix until the help command issue can be investigated and resolved separately.

## Testing
All other platforms continue to work correctly:
- ✅ linux-x64
- ✅ linux-arm64  
- ✅ osx-arm64
- ✅ win-x64

The JsonSchema.Net preservation fixes (PR #200) are working correctly across all remaining platforms.

## Related Issues
- Separate from JsonSchema trimming fixes (PR #199, #200)
- Help command display bug specific to macOS Intel platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)