### PR TITLE
fix: preserve VersionInfo class during trimming

### DIFF
--- a/src/Morphir/ILLink.Descriptors.xml
+++ b/src/Morphir/ILLink.Descriptors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Trimming descriptor to preserve generated VersionInfo class for --version flag.
+  The VersionInfo class is generated at build time and needs to be preserved
+  during trimming for the version command to work correctly.
+-->
+<linker>
+    <!-- Preserve generated VersionInfo class -->
+    <assembly fullname="morphir">
+        <type fullname="Morphir.VersionInfo" preserve="all" />
+    </assembly>
+</linker>

--- a/src/Morphir/Morphir.csproj
+++ b/src/Morphir/Morphir.csproj
@@ -36,6 +36,11 @@
     <!-- See justfile publish-executable task for publish-time settings -->
 
     <ItemGroup>
+        <!-- Preserve generated VersionInfo during trimming -->
+        <TrimmerRootDescriptor Include="ILLink.Descriptors.xml" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Extism.runtime.all" />
         <PackageReference Include="Extism.Sdk" />
         <PackageReference Include="JasperFx.CodeGeneration.Commands" />


### PR DESCRIPTION
## Summary
Add ILLink.Descriptors.xml to preserve the generated VersionInfo class during trimming.

## Problem
After merging PR #200 and #201, deployment E2E tests started failing across all platforms with version command outputting unexpected text ("Description:") instead of the semantic version number.

Root cause: The trimmer was removing the generated `VersionInfo.g.cs` class because there was no trimming descriptor to preserve it.

## Solution
Created [src/Morphir/ILLink.Descriptors.xml](src/Morphir/ILLink.Descriptors.xml) to explicitly preserve the `Morphir.VersionInfo` type during trimming:

```xml
<assembly fullname="morphir">
    <type fullname="Morphir.VersionInfo" preserve="all" />
</assembly>
```

Updated [Morphir.csproj](src/Morphir/Morphir.csproj) to reference the trimming descriptor.

## Testing
This fix should resolve the E2E test failures on all platforms:
- linux-x64
- linux-arm64
- osx-arm64
- win-x64

The `--version` flag should now correctly output the semantic version number instead of failing.

## Related Issues
- Regression introduced after PR #200 (JsonSchema.Net preservation)
- Affects deployment workflow run 20294533876

🤖 Generated with [Claude Code](https://claude.com/claude-code)