### PR TITLE
fix: remove illegal double dash from XML comment

### DIFF
--- a/src/Morphir/ILLink.Descriptors.xml
+++ b/src/Morphir/ILLink.Descriptors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Trimming descriptor to preserve generated VersionInfo class for --version flag.
+  Trimming descriptor to preserve generated VersionInfo class for version flag.
   The VersionInfo class is generated at build time and needs to be preserved
   during trimming for the version command to work correctly.
 -->


### PR DESCRIPTION
## Summary
Fix XML parsing error in ILLink.Descriptors.xml by removing illegal double dash from comment.

## Problem
PR #202 introduced an ILLink.Descriptors.xml file with an XML comment containing `--version`. XML specification forbids `--` within comments, causing IL Trimmer to fail with:

```
System.Xml.XmlException: An XML comment cannot contain '--', and '-' cannot be the last character. Line 3, position 67.
```

This caused deployment builds to fail on all platforms (linux-x64, linux-arm64, osx-arm64, win-x64).

## Solution
Changed comment from:
```xml
<!-- ... for --version flag ... -->
```

To:
```xml
<!-- ... for version flag ... -->
```

Removing the double dash while preserving the comment's meaning.

## Testing
- Local build succeeds with corrected XML
- Should fix IL Trimmer errors in deployment workflow

## Related
- Regression from PR #202 (VersionInfo preservation)
- Affects deployment workflow run 20294759570

🤖 Generated with [Claude Code](https://claude.com/claude-code)