### PR TITLE
chore: update release to v0.3.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-**NOTE**: This is a pre-release version. Stable v0.3.0 pending LanguageExt.Core 5.0 stable release.
+- **NOTE**: This is a pre-release version. Stable v0.3.0 pending LanguageExt.Core 5.0 stable release.
 - Serilog logging infrastructure for CLI tools (Serilog, Serilog.Extensions.Hosting, Serilog.Sinks.Console)
 - CLI logging standards documentation in AGENTS.md and CLAUDE.md
 - `.morphir/out/` directory to .gitignore


### PR DESCRIPTION
## Summary

Update release from v0.3.0 to v0.3.0-rc.1 due to NuGet prerelease dependency constraint.

## Background

The v0.3.0 release failed during package publishing with error:
```
NU5104: A stable release of a package should not have a prerelease dependency
```

The project depends on `LanguageExt.Core 5.0.0-beta-61` (prerelease), so we cannot publish a stable version until that dependency becomes stable.

## Changes

- Version: `0.3.0` → `0.3.0-rc.1`
- Added note to CHANGELOG about RC status
- Updated comparison links

## Next Steps

After this PR merges:
1. Trigger deployment workflow with `--field release-version=0.3.0-rc.1`
2. Monitor and verify RC release
3. Plan stable v0.3.0 release when LanguageExt.Core 5.0 stable is available

## Related

- Tracking Issue: #222
- Failed Workflow: https://github.com/finos/morphir-dotnet/actions/runs/20353068239

🤖 Generated with [Claude Code](https://claude.com/claude-code)