### PR TITLE
fix: use plugin-version parameter for proto plugin packaging

### DIFF
--- a/.github/workflows/proto-plugin-release.yml
+++ b/.github/workflows/proto-plugin-release.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./build.sh --target BuildProtoPlugin
 
       - name: Package Proto Plugin
-        run: ./build.sh --target PackageProtoPlugin --version ${{ env.PLUGIN_VERSION }}
+        run: ./build.sh --target PackageProtoPlugin --plugin-version ${{ env.PLUGIN_VERSION }}
 
       - name: Upload Plugin Artifact
         uses: actions/upload-artifact@v4

--- a/build/Build.ProtoPlugin.cs
+++ b/build/Build.ProtoPlugin.cs
@@ -16,6 +16,9 @@ partial class Build
     [Parameter("Output directory for proto plugin WASM")]
     readonly AbsolutePath ProtoPluginDir = RootDirectory / "artifacts" / "proto-plugin";
 
+    [Parameter("Version for the proto plugin release (e.g., 0.1.0)")]
+    readonly string PluginVersion;
+
     AbsolutePath ProtoPluginProjectDir => RootDirectory / "integrations" / "rust" / "morphir-wasm-proto-plugin";
 
     /// <summary>
@@ -116,9 +119,10 @@ partial class Build
         {
             Serilog.Log.Information("Packaging Proto WASM plugin...");
 
+            var pluginVer = PluginVersion ?? throw new Exception("PluginVersion parameter is required for PackageProtoPlugin target");
             var wasmFile = ProtoPluginDir / "morphir_plugin.wasm";
             var readmeFile = ProtoPluginProjectDir / "README.md";
-            var tarballName = $"morphir-proto-plugin-v{Version}.tar.gz";
+            var tarballName = $"morphir-proto-plugin-v{pluginVer}.tar.gz";
             var tarballPath = ProtoPluginDir / tarballName;
 
             // Create a staging directory for the tarball contents


### PR DESCRIPTION
## Summary

Fixes the proto plugin release workflow by using a dedicated `--plugin-version` parameter instead of the Morphir `--version` parameter.

## Problem

The `PackageProtoPlugin` target was using the Morphir `Version` property (0.3.0-rc.1) instead of the plugin version (0.1.0), causing the tarball to be created with the wrong filename:
- Created: `morphir-proto-plugin-v0.3.0-rc.1.tar.gz` 
- Expected: `morphir-proto-plugin-v0.1.0.tar.gz`

This caused the release workflow to fail when trying to upload the tarball to GitHub releases.

## Solution

- Add `PluginVersion` parameter to `Build.ProtoPlugin.cs`
- Update `PackageProtoPlugin` target to use `PluginVersion` instead of `Version`
- Update workflow to pass `--plugin-version` instead of `--version`

## Testing

- [x] Pre-commit hooks passed (changelog validation, format check)
- [ ] Will test with workflow re-run after merge

## Related

- Follows up on PR #233 (proto plugin implementation)
- Enables successful execution of the Proto Plugin Release workflow

🤖 Generated with Claude Code