### PR TITLE
feat: add GitHub release creation to deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -160,6 +160,10 @@ jobs:
             - name: Publish packages to NuGet
               run: ./build.sh --target PublishAll --api-key ${{ env.NUGET_TOKEN }} --nuget-source https://api.nuget.org/v3/index.json
 
+            - name: Create GitHub Release
+              if: ${{ env.SKIP_GIT_RELEASE != 'true' }}
+              run: ./build.sh --target CreateGitHubRelease --version ${{ env.RELEASE_VERSION }}
+
     cd:
         runs-on: ubuntu-latest
         needs: [validate-release-version, release]

--- a/build/Build.Packaging.cs
+++ b/build/Build.Packaging.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
@@ -90,5 +92,66 @@ partial class Build
         .Executes(() =>
         {
             Serilog.Log.Information("All packages created successfully");
+        });
+
+    /// <summary>
+    /// Create platform-specific tarballs from single-file executables
+    /// Input: artifacts/single-file/{rid}/morphir[.exe]
+    /// Output: artifacts/morphir-{rid}-v{version}.tar.gz
+    /// Used by deployment workflow to create GitHub release assets
+    /// </summary>
+    Target PackPlatformTarballs => _ => _
+        .Description("Create platform-specific tarballs for GitHub releases")
+        .Executes(() =>
+        {
+            var singleFileDir = RootDirectory / "artifacts" / "single-file";
+            var artifactsDir = RootDirectory / "artifacts";
+
+            if (!Directory.Exists(singleFileDir))
+            {
+                throw new Exception($"Single-file directory not found: {singleFileDir}. Run build-executables job first.");
+            }
+
+            var versionString = Version.ToString();
+            Serilog.Log.Information($"Creating platform tarballs for version {versionString}...");
+
+            // Find all RID directories
+            var ridDirs = Directory.GetDirectories(singleFileDir)
+                .Select(d => new DirectoryInfo(d).Name)
+                .Where(name => !name.Equals("staging", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (!ridDirs.Any())
+            {
+                throw new Exception($"No RID directories found in {singleFileDir}");
+            }
+
+            foreach (var rid in ridDirs)
+            {
+                var ridDir = singleFileDir / rid;
+                var tarballName = $"morphir-{rid}-v{versionString}.tar.gz";
+                var tarballPath = artifactsDir / tarballName;
+
+                Serilog.Log.Information($"Creating tarball for {rid}...");
+
+                // Create tarball using cross-platform tar
+                var tarExitCode = RunCommand(
+                    "tar",
+                    "-czf",
+                    tarballPath,
+                    "-C", ridDir,
+                    "."
+                );
+
+                if (tarExitCode != 0)
+                {
+                    throw new Exception($"Failed to create tarball for {rid} (exit code: {tarExitCode})");
+                }
+
+                var size = GetFileSize(tarballPath);
+                Serilog.Log.Information($"✓ Created {tarballName} ({size})");
+            }
+
+            Serilog.Log.Information($"✓ All platform tarballs created successfully");
         });
 }

--- a/build/Build.Publishing.cs
+++ b/build/Build.Publishing.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -294,5 +295,112 @@ partial class Build
             Serilog.Log.Information($"  4. Create PR: gh pr create --title \"chore: prepare release {ReleaseVersion}\"");
             Serilog.Log.Information($"  5. After merge, tag: git tag -a v{ReleaseVersion} -m \"Release {ReleaseVersion}\"");
             Serilog.Log.Information($"  6. Push tag: git push origin v{ReleaseVersion}");
+        });
+
+    /// <summary>
+    /// Create a GitHub release with platform-specific executable tarballs
+    /// Requires: Platform tarballs created by PackPlatformTarballs target
+    /// Input: artifacts/morphir-{rid}-v{version}.tar.gz
+    /// Output: GitHub release at https://github.com/finos/morphir-dotnet/releases/tag/v{version}
+    /// Parameters: --version (required)
+    /// </summary>
+    Target CreateGitHubRelease => _ => _
+        .DependsOn(PackPlatformTarballs)
+        .Description("Create a GitHub release with platform-specific executables")
+        .Executes(() =>
+        {
+            var versionString = Version.ToString();
+            var releaseTag = $"v{versionString}";
+            var artifactsDir = RootDirectory / "artifacts";
+
+            Serilog.Log.Information($"Creating GitHub release for {releaseTag}...");
+
+            // Find all platform tarballs
+            var tarballs = Directory.GetFiles(artifactsDir, $"morphir-*-v{versionString}.tar.gz")
+                .ToList();
+
+            if (!tarballs.Any())
+            {
+                throw new Exception($"No platform tarballs found in {artifactsDir}. Run PackPlatformTarballs first.");
+            }
+
+            Serilog.Log.Information($"Found {tarballs.Count} platform tarballs");
+
+            // Create release notes file
+            var releaseNotesPath = artifactsDir / "release-notes.md";
+            var releaseNotes = $@"# Morphir .NET v{versionString}
+
+Platform-specific executables for the Morphir CLI.
+
+## Installation
+
+### Using proto (recommended)
+
+```bash
+# Install proto plugin
+proto plugin add morphir ""source:https://github.com/finos/morphir-dotnet/releases/download/plugin-v0.1.0/morphir_plugin.wasm""
+
+# Install Morphir
+proto install morphir {versionString}
+```
+
+### Manual installation
+
+Download the appropriate tarball for your platform and extract it:
+
+```bash
+# Linux x64
+wget https://github.com/finos/morphir-dotnet/releases/download/v{versionString}/morphir-linux-x64-v{versionString}.tar.gz
+tar -xzf morphir-linux-x64-v{versionString}.tar.gz
+
+# macOS ARM64 (Apple Silicon)
+wget https://github.com/finos/morphir-dotnet/releases/download/v{versionString}/morphir-osx-arm64-v{versionString}.tar.gz
+tar -xzf morphir-osx-arm64-v{versionString}.tar.gz
+
+# Windows x64
+wget https://github.com/finos/morphir-dotnet/releases/download/v{versionString}/morphir-win-x64-v{versionString}.tar.gz
+tar -xzf morphir-win-x64-v{versionString}.tar.gz
+```
+
+## Supported Platforms
+
+- Linux (x64, arm64)
+- macOS (x64, arm64/Apple Silicon)
+- Windows (x64)
+
+## NuGet Packages
+
+This release is also available on NuGet:
+- [Morphir](https://www.nuget.org/packages/Morphir/{versionString}) - CLI tool
+- [Morphir.Core](https://www.nuget.org/packages/Morphir.Core/{versionString}) - Core library
+- [dotnet-morphir](https://www.nuget.org/packages/dotnet-morphir/{versionString}) - .NET global tool
+
+## Resources
+
+- [Morphir Documentation](https://morphir.finos.org/)
+- [GitHub Repository](https://github.com/finos/morphir-dotnet)
+- [FINOS Morphir](https://github.com/finos/morphir)
+";
+
+            File.WriteAllText(releaseNotesPath, releaseNotes);
+            Serilog.Log.Information($"✓ Created release notes: {releaseNotesPath}");
+
+            // Build gh release create command with all tarballs
+            var tarballArgs = string.Join(" ", tarballs.Select(t => $"\"{t}\""));
+            var ghCommand = $"release create \"{releaseTag}\" " +
+                           $"--title \"Morphir .NET v{versionString}\" " +
+                           $"--notes-file \"{releaseNotesPath}\" " +
+                           tarballArgs;
+
+            Serilog.Log.Information("Creating GitHub release...");
+            var exitCode = RunCommand("gh", ghCommand.Split(' '));
+
+            if (exitCode != 0)
+            {
+                throw new Exception($"Failed to create GitHub release (exit code: {exitCode})");
+            }
+
+            Serilog.Log.Information($"✓ GitHub release created successfully");
+            Serilog.Log.Information($"  View at: https://github.com/finos/morphir-dotnet/releases/tag/{releaseTag}");
         });
 }


### PR DESCRIPTION
## Summary

Adds automated GitHub release creation to the deployment workflow, enabling the proto plugin to download and install Morphir executables.

## Problem

The deployment workflow was publishing NuGet packages but **not creating GitHub releases** with platform-specific executables. This caused:

1. No GitHub releases for recent versions (v0.3.0-rc.1, etc.)
2. Proto plugin unable to download Morphir executables
3. Missing distribution channel for platform-specific binaries

The `skip-git-release` parameter existed but had no corresponding implementation.

## Solution

### New Nuke Build Targets

**PackPlatformTarballs** ([Build.Packaging.cs:103-156](build/Build.Packaging.cs#L103-L156))
- Creates platform-specific tarballs from single-file executables
- Output format: `morphir-{rid}-v{version}.tar.gz`
- Matches proto plugin's expected naming convention
- Cross-platform tar support

**CreateGitHubRelease** ([Build.Packaging.cs:300-405](build/Build.Publishing.cs#L300-L405))
- Creates GitHub release with all platform tarballs as assets
- Generates comprehensive release notes with:
  - Proto plugin installation instructions
  - Manual installation guides for each platform
  - Links to NuGet packages
  - Platform support matrix
- Uses `gh` CLI for release creation
- Honors `skip-git-release` parameter

### Workflow Integration

[deployment.yml:163-165](.github/workflows/deployment.yml#L163-L165)
- Added CreateGitHubRelease step after NuGet publishing
- Conditionally executes based on `skip-git-release` parameter
- Follows Nuke pattern for consistency

## Testing

- [x] New Nuke targets compile successfully
- [x] Pre-commit hooks passed
- [ ] Will test end-to-end with next Morphir release
- [ ] Proto plugin will be able to install Morphir once releases are created

## Impact

- **Proto plugin functional**: Users can install Morphir via `proto install morphir`
- **Complete release artifacts**: GitHub releases will have both NuGet packages and executables
- **Consistent build system**: Uses Nuke targets instead of inline bash scripts
- **Better documentation**: Release notes include multiple installation methods

## Example Release

Once this merges, the next Morphir release will create a GitHub release like:

```
Morphir .NET v0.3.0

Platform-specific executables for the Morphir CLI.

Installation:
- proto install morphir 0.3.0
- Manual download and extract

Assets:
- morphir-linux-x64-v0.3.0.tar.gz
- morphir-linux-arm64-v0.3.0.tar.gz  
- morphir-osx-arm64-v0.3.0.tar.gz
- morphir-win-x64-v0.3.0.tar.gz
```

## Related

- Completes the proto plugin feature (PR #233, #234)
- Fixes missing GitHub releases preventing proto plugin usage
- Aligns with Nuke build system patterns

🤖 Generated with Claude Code