### PR TITLE
docs: expose Contributing and Design sections as top-level navigation

### DIFF
--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -1,15 +1,26 @@
 ---
 title: "Contributing"
 linkTitle: "Contributing"
-weight: 40
+weight: 30
+menu:
+  main:
+    weight: 30
 description: "How to contribute to Morphir .NET"
 ---
 
-Thank you for your interest in contributing to Morphir .NET! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Morphir .NET! This section provides guidelines, instructions, and design documentation for contributing to the project.
+
+## Quick Links
+
+- **[Design & Architecture](./design/)**: AI Skill Framework, guru philosophy, and creation guides
+- **[Development Setup](#development-setup)**: Get your environment ready
+- **[Contribution Workflow](#pull-request-process)**: How to submit changes
+- **[Code Standards](#coding-standards)**: What we expect
+- **[QA & Testing](./qa/)**: Testing practices and playbooks
 
 ## Getting Started
 
-1. Fork the repository
+1. Fork the [repository](https://github.com/finos/morphir-dotnet)
 2. Clone your fork
 3. Create a branch for your changes
 4. Make your changes
@@ -40,29 +51,69 @@ dotnet test --nologo
 dotnet format
 ```
 
+### Install Git Hooks
+
+```bash
+dotnet tool restore
+dotnet husky install
+```
+
 ## Coding Standards
 
 - Follow the existing code style
 - Use C# 14 features where appropriate
 - Prefer immutable data structures
-- Write comprehensive tests
+- Write comprehensive tests (TDD approach)
 - Update documentation as needed
+- Follow [AGENTS.md](https://github.com/finos/morphir-dotnet/blob/main/AGENTS.md) for architectural guidance
 
 ## Pull Request Process
 
-1. Ensure all tests pass
-2. Run code formatters
+1. Ensure all tests pass: `dotnet test --nologo`
+2. Run code formatters: `dotnet format`
 3. Update documentation if needed
 4. Create a focused PR with a clear description
 5. Follow [Conventional Commits](https://www.conventionalcommits.org/) format
+6. Ensure DCO is signed (see [CONTRIBUTING.md](https://github.com/finos/morphir-dotnet/blob/main/CONTRIBUTING.md))
+
+## Design & Architecture
+
+### For New Features
+
+Start with the **[Design Documentation](./design/)** section:
+- Understand the [AI Skill Framework](./design/skill-framework-design.md) for tooling features
+- Review [Guru Philosophy](./design/guru-philosophy.md) to understand continuous improvement patterns
+- Follow the [Guru Creation Guide](./design/guru-creation-guide.md) for new AI skills
+- Create a PRD (Product Requirements Document) in `docs/content/contributing/design/prds/`
+
+### For Existing Features
+
+- Check existing issues and PRs
+- Review related code and tests
+- Understand the architecture (see [AGENTS.md](https://github.com/finos/morphir-dotnet/blob/main/AGENTS.md))
+
+## Testing & Quality
+
+See **[QA & Testing](./qa/)** for comprehensive guidance on:
+- Test strategies and best practices
+- Regression testing
+- BDD scenarios
+- Test coverage requirements
 
 ## Code of Conduct
 
 Please read and follow our [Code of Conduct](/code-of-conduct/).
 
-## Questions?
+## Need Help?
 
-- Open an issue on GitHub
-- Join our discussions
+- **Questions**: Open an issue on [GitHub](https://github.com/finos/morphir-dotnet/issues)
+- **Discussions**: Join our [discussions](https://github.com/finos/morphir-dotnet/discussions)
+- **FINOS Slack**: `#morphir` channel on [FINOS Slack](https://finos-lf.slack.com/)
+
+## Key Resources
+
+- [AGENTS.md](https://github.com/finos/morphir-dotnet/blob/main/AGENTS.md) - Comprehensive guidance for AI agents and developers
+- [CONTRIBUTING.md](https://github.com/finos/morphir-dotnet/blob/main/CONTRIBUTING.md) - DCO and legal requirements
+- [README.md](https://github.com/finos/morphir-dotnet/blob/main/README.md) - Project overview
 - Check the [AGENTS.md](https://github.com/finos/morphir-dotnet/blob/main/AGENTS.md) for detailed development guidelines
 

--- a/docs/content/contributing/design/_index.md
+++ b/docs/content/contributing/design/_index.md
@@ -1,29 +1,56 @@
 ---
 title: "Design Documentation"
 linkTitle: "Design"
-weight: 20
-description: "Design documents, PRDs, and architectural specifications for Morphir .NET"
+weight: 10
+menu:
+  main:
+    parent: "Contributing"
+    weight: 10
+description: "Design documents, PRDs, and architectural specifications for Morphir .NET. Includes AI Skill Framework architecture, guru philosophy, and creation guides."
 ---
 
 # Design Documentation
 
-This section contains design documentation for Morphir .NET, including Product Requirements Documents (PRDs), architectural specifications, and design patterns.
+This section contains design documentation for Morphir .NET, including:
+- **AI Skill Framework**: Architecture for cross-agent AI skills (gurus)
+- **Product Requirements Documents (PRDs)**: Feature specifications and implementation tracking
+- **Architectural specifications**: Design patterns and decision records
 
-## Contents
+## Key Documents
+
+### AI Skill Framework & Gurus
+
+- **[AI Skill Framework Design](./skill-framework-design.md)**: Comprehensive architecture for unified, cross-agent AI skills with continuous improvement and proactive review capabilities
+- **[Guru Philosophy](./guru-philosophy.md)**: The collaborative AI stewardship philosophy behind morphir-dotnet gurus, including stewardship, continuous improvement, proactive review, automation, collaboration, and teaching principles
+- **[Guru Creation Guide](./guru-creation-guide.md)**: Step-by-step guide for creating new AI gurus, including decision framework, implementation structure, automation strategy, review capability design, and success criteria
+
+### Design Artifacts
 
 - **[Product Requirements Documents (PRDs)](./prds/)**: Comprehensive feature specifications and implementation tracking
 - **Architectural Decision Records**: See `docs/adr/` in the repository root
 
 ## Design Process
 
+### Standard Features
 1. **PRD Creation**: Major features start with a comprehensive PRD
 2. **Review & Approval**: PRDs are reviewed before implementation begins
 3. **Implementation**: PRDs are updated with implementation notes as work progresses
 4. **Completion**: Completed PRDs serve as historical reference
 
-## Contributing
+### AI Skills & Gurus
+1. **Philosophy First**: Understand guru principles before design
+2. **Framework Definition**: Follow skill framework architecture
+3. **Review Capability**: Every guru includes proactive review capability (see Part 5B in creation guide)
+4. **Cross-Agent Design**: Ensure portability across Claude, Copilot, Cursor, and other agents
+5. **Retrospective Integration**: Plan for continuous improvement through feedback loops
+6. **Quarterly Review**: Establish periodic review and improvement process
 
-See the [Contributing Guide](../_index.md) for information on how to contribute to Morphir .NET.
+## Quick Links
+
+- [Contributing to Morphir .NET](../_index.md)
+- [Morphir Documentation](/docs/)
+- [Getting Started](/getting-started/)
+- [GitHub Repository](https://github.com/finos/morphir-dotnet)
 
 ---
 

--- a/docs/content/contributing/design/guru-creation-guide.md
+++ b/docs/content/contributing/design/guru-creation-guide.md
@@ -1,0 +1,877 @@
+---
+title: "Guru Creation Guide"
+description: "Step-by-step guide for creating new AI gurus in morphir-dotnet"
+weight: 102
+---
+
+# Guru Creation Guide
+
+## Overview
+
+This guide walks through the process of creating a new guru (AI skill) in morphir-dotnet. It establishes a repeatable pattern that ensures consistency, quality, and alignment with the guru philosophy.
+
+A guru should be created when you have a domain of expertise that:
+- Is distinct and has clear boundaries
+- Crosses multiple project areas or is deep within one area
+- Has 3+ core competencies (expertise areas)
+- Contains repetitive work suitable for automation
+
+## Part 1: Should This Be a Guru?
+
+### Decision Framework
+
+Ask yourself these questions in order:
+
+#### 1. Is it a distinct domain?
+- **Question:** Can I clearly define what this guru owns?
+- **Examples:** Yes
+  - Testing/QA (QA Tester)
+  - AOT optimization (AOT Guru)
+  - Release management (Release Manager)
+  - Elm-to-F# migration (Elm-to-F# Guru)
+- **Examples:** No
+  - "Helping with random coding tasks" (too broad)
+  - "One-off problem solving" (not a domain)
+
+#### 2. Does it justify deep expertise?
+- **Question:** Is there enough depth to warrant 20+ patterns and multiple playbooks?
+- **Examples:** Yes
+  - QA has 20+ testing patterns (unit, BDD, E2E, property-based, etc.)
+  - AOT has 15+ IL error categories and workarounds
+  - Release has 4 playbooks (standard, hotfix, pre-release, recovery)
+- **Examples:** No
+  - One-off task (create a simple script instead)
+  - Straightforward process (document in AGENTS.md instead)
+
+#### 3. Will it have 3+ core competencies?
+- **Question:** Can I identify at least 3 areas of expertise?
+- **Examples:** Yes
+  - QA: Test planning, automation, coverage tracking, bug reporting, BDD design
+  - AOT: Diagnostics, size optimization, source generators, Myriad, IL parsing
+  - Release: Version management, changelog handling, deployment monitoring, recovery
+- **Examples:** No
+  - Only 1-2 areas (document as section of existing guru or create guide)
+
+#### 4. Is there high-token-cost repetitive work?
+- **Question:** Will automation save significant tokens or effort?
+- **Examples:** Yes
+  - Release: Monitoring workflow status manually (tokens) → autonomous polling (few tokens)
+  - AOT: Reading IL warnings manually (tokens) → automated analysis (few tokens)
+  - QA: Running tests manually (tokens) → automated test runner (few tokens)
+- **Examples:** No
+  - Guidance only (no scripts needed, create .agents/ guide instead)
+  - One-off automation (create a utility script, not a guru)
+
+#### 5. Will it coordinate with other gurus?
+- **Question:** Does this domain have clear integration points?
+- **Examples:** Yes
+  - Elm-to-F# → AOT Guru (verify generated code is AOT-compatible)
+  - Elm-to-F# → QA Tester (verify test coverage)
+  - Release Manager ↔ QA Tester (post-release verification)
+- **Examples:** No
+  - Isolated domain (could be .agents/ guide or standalone skill)
+
+### Decision Result
+
+**If all 5 questions are YES → Create a guru skill**
+
+**If any are NO → Consider alternatives:**
+- Just 1-2 competencies? → Create `.agents/{topic}.md` guide instead
+- No automation opportunity? → Document decision trees in AGENTS.md
+- No coordination needed? → Create standalone utility or guide
+- Too narrow/specific? → Create template or plugin, not full guru
+
+## Part 2: Guru Definition
+
+### Step 1: Define the Domain
+
+Write a clear 2-3 sentence description:
+```
+Domain: Release Management
+Description: Orchestrating the complete release lifecycle from version planning 
+through deployment and verification. Ensures releases are reliable, predictable, 
+and recoverable.
+```
+
+### Step 2: Define Competencies
+
+List primary and secondary competencies:
+
+**Primary Competencies (3-6 core areas):**
+1. Version Management - Semantic versioning, version detection
+2. Changelog Management - Keep a Changelog format, parsing, generation
+3. Deployment Orchestration - Workflow automation, status tracking
+4. Verification & Recovery - Post-release checks, failure recovery
+5. Process Improvement - Retrospectives, playbook evolution
+6. Documentation - Comprehensive playbooks, decision trees
+
+**Secondary Competencies (2-4 supporting areas):**
+1. Git/GitHub Coordination - Tag management, branch strategies
+2. CI/CD Integration - GitHub Actions, workflow triggers
+3. Communication - Status updates, failure alerts
+4. Historical Analysis - Release metrics, trend tracking
+
+### Step 3: Define Responsibilities
+
+What is this guru accountable for?
+
+```
+Release Manager Responsibilities:
+- Ensure releases happen on schedule without surprises
+- Prevent release failures through pre-flight validation
+- Enable fast recovery if failures occur
+- Improve the release process continuously (quarterly reviews)
+- Communicate clearly about status and blockers
+- Coordinate with QA on verification and AOT Guru on version compatibility
+```
+
+### Step 4: Define Scope Boundaries
+
+What is explicitly NOT this guru's responsibility?
+
+```
+Release Manager Does NOT:
+- Make product decisions about what features to include
+- Review code quality (that's QA Tester's job)
+- Decide version numbering policies (that's maintainers' decision)
+- Handle security issues (that's future Security Guru's job)
+- Manage documentation (that's future Documentation Guru's job)
+```
+
+### Step 5: Map Coordination Points
+
+Identify other gurus this will coordinate with:
+
+```
+Release Manager Coordination:
+- WITH QA Tester: Hand-off after release for verification
+  - Trigger: Release deployed
+  - Signal: "Ready for post-release QA?"
+  - Response: Test results, coverage, functional verification
+  
+- WITH AOT Guru: Verify version tags are AOT-compatible
+  - Trigger: Before publishing release
+  - Signal: "Can I publish this version?"
+  - Response: AOT status, any breaking changes
+  
+- WITH Elm-to-F# Guru: Track feature parity milestones
+  - Trigger: Migration progress updates
+  - Signal: "What's our migration status for this release?"
+  - Response: Completed modules, parity progress
+```
+
+## Part 3: Implementation Structure
+
+### Directory Layout
+
+Create the following structure:
+
+```
+.claude/skills/{guru-name}/
+├── skill.md                    # Main skill prompt (1000-1200 lines)
+├── README.md                   # Quick start guide (300-400 lines)
+├── MAINTENANCE.md              # Quarterly review process
+├── scripts/
+│   ├── automation-1.fsx        # High-token-cost task automation
+│   ├── automation-2.fsx        # High-token-cost task automation
+│   ├── automation-3.fsx        # High-token-cost task automation
+│   └── common.fsx              # Shared utilities
+├── templates/
+│   ├── {decision-type}-decision.md
+│   ├── {workflow-type}-workflow.md
+│   └── issue-template.md
+└── patterns/
+    ├── pattern-1.md
+    ├── pattern-2.md
+    └── [more patterns discovered over time]
+```
+
+### skill.md Structure
+
+Your main skill file should contain:
+
+```markdown
+---
+id: {guru-id}
+name: {Guru Name}
+triggers:
+  - keyword1
+  - keyword2
+  - keyword3
+---
+
+# {Guru Name}
+
+## Overview
+[2-3 sentences about the guru]
+
+## Responsibilities
+[List of core responsibilities]
+
+## Competencies
+[Detailed list of competencies with examples]
+
+## Decision Trees
+[3-5 decision trees for common scenarios]
+
+## Playbooks
+[3-5 detailed workflows]
+
+## Pattern Catalog
+[Growing collection of patterns]
+
+## Automation
+[Available F# scripts]
+
+## Integration Points
+[How this guru coordinates with others]
+
+## Feedback Loop
+[How this guru improves over time]
+
+## Related Resources
+[Links to guides, documentation, templates]
+```
+
+**Size Target:** 1000-1200 lines (~50 KB)
+
+### README.md Structure
+
+Quick reference for users:
+
+```markdown
+# {Guru Name} - Quick Reference
+
+## What This Guru Does
+[One paragraph overview]
+
+## When to Use This Guru
+[List of scenarios]
+
+## Core Competencies
+[Quick bullet list]
+
+## Available Scripts
+[Table of scripts with descriptions]
+
+## Common Tasks
+[Quick how-tos]
+
+## Pattern Catalog
+[Index of patterns]
+
+## Examples
+[Real examples from the project]
+
+## Integration
+[How to use this guru with others]
+
+## References
+[Links to related documentation]
+```
+
+**Size Target:** 300-400 lines (~16 KB)
+
+### MAINTENANCE.md Structure
+
+Guidance for maintaining this guru:
+
+```markdown
+# Maintenance Guide
+
+## Quarterly Review Checklist
+- [ ] Read through collected feedback
+- [ ] Identify 2-3 improvements for next quarter
+- [ ] Update patterns that changed
+- [ ] Create/update Myriad plugins if automation opportunities exist
+- [ ] Document learnings in Implementation Notes
+- [ ] Update success metrics
+
+## Feedback Collection
+- Where feedback is captured: [GitHub issue, tracking doc, etc.]
+- Review schedule: [Quarterly, per-release, etc.]
+- Stakeholders to consult: [maintainers, project leads]
+
+## Improvement Process
+1. Collect feedback
+2. Identify patterns
+3. Update playbooks/templates
+4. Test changes
+5. Document in changelog
+6. Publish update
+
+## Version History
+[Track skill evolution]
+```
+
+### F# Scripts
+
+Create 3-5 scripts targeting high-token-cost tasks:
+
+**Script Template:**
+
+```fsharp
+#!/usr/bin/env -S dotnet fsi
+
+/// Automation Script: {Purpose}
+/// Saves {N} tokens per use by automating {high-token-cost task}
+/// Usage: dotnet fsi {script-name}.fsx [args]
+
+#r "nuget: Spectre.Console"
+open Spectre.Console
+
+let main argv =
+    // Parse arguments
+    // Analyze/test/validate something
+    // Print results
+    0
+
+exit (main fsx.CommandLineArgs.[1..])
+```
+
+**Script checklist:**
+- [ ] Clear purpose stated in comments
+- [ ] Token savings estimated
+- [ ] Usage documented
+- [ ] Error handling included
+- [ ] JSON output option (for automation)
+- [ ] Progress indicators (for long-running scripts)
+
+### Templates
+
+Create domain-specific templates:
+
+**Decision Template:**
+```markdown
+# Decision: {Decision Type}
+
+## Scenario
+[When would you make this decision?]
+
+## Options
+1. Option A
+   - Pros: ...
+   - Cons: ...
+   - When to use: ...
+
+2. Option B
+   - Pros: ...
+   - Cons: ...
+   - When to use: ...
+
+## Recommendation
+[What does the guru recommend?]
+
+## Examples
+[Real examples from the project]
+```
+
+**Workflow Template:**
+```markdown
+# Workflow: {Workflow Name}
+
+## Overview
+[What does this workflow accomplish?]
+
+## Prerequisites
+[What must be true before starting?]
+
+## Steps
+1. Step 1 - [description]
+2. Step 2 - [description]
+...
+
+## Validation
+[How do you know it worked?]
+
+## Rollback
+[How do you undo if it fails?]
+
+## Related Workflows
+[Links to similar workflows]
+```
+
+### Pattern Catalog
+
+Start with 5-10 seed patterns, add more as discovered:
+
+**Pattern Entry Template:**
+```markdown
+# Pattern: {Pattern Name}
+
+## Description
+[What is this pattern?]
+
+## Context
+[When and why would you use it?]
+
+## Examples
+[Real code examples]
+
+## Pros and Cons
+[Trade-offs]
+
+## Related Patterns
+[Similar or complementary patterns]
+
+## References
+[Links to documentation or standards]
+```
+
+## Part 4: Automation Strategy
+
+### Identify High-Token-Cost Tasks
+
+For your guru domain, identify 5-10 repetitive tasks:
+
+**Release Manager Example:**
+1. Check GitHub Actions status (manual every 5 min = many tokens)
+2. Prepare release checklist (manual validation = tokens)
+3. Validate post-release status (manual testing = tokens)
+4. Extract release history for notes (manual searching = tokens)
+5. Detect process changes (manual review = tokens)
+
+### Prioritize for Automation
+
+Score tasks on:
+- **Frequency:** How often does this happen? (1-5 scale)
+- **Token Cost:** How many tokens does it cost? (1-5 scale)
+- **Repetitiveness:** Is this the same every time? (1-5 scale)
+
+```
+Task                          Frequency  Token Cost  Repetitive  Priority
+Monitor release status        5 (every few min)  3       5        Critical
+Prepare checklist             3 (per release)    2       5        High
+Post-release validation       3 (per release)    3       5        High
+Extract release history       2 (per release)    2       3        Medium
+Detect process changes        1 (quarterly)      2       4        Medium
+```
+
+**Select top 3-5 for automation**
+
+### Design Automation Scripts
+
+For each task, design an F# script:
+
+**Script Design Pattern:**
+1. **Input:** What data does this need?
+2. **Processing:** What analysis/transformation?
+3. **Output:** What does it return?
+4. **Token Savings:** How much does this save?
+
+**Example: Monitor Release Status**
+```
+Input: GitHub Action workflow ID
+Processing: Poll GitHub Actions API, track status
+Output: Current status, elapsed time, next check
+Token Savings: 100+ tokens per hour (vs. manual polling)
+```
+
+## Part 5: Feedback Mechanisms
+
+### Design Feedback Capture
+
+Define when and how the guru learns:
+
+**Trigger Points:**
+- After workflow completion? (success/failure)
+- After N sessions? (every 5 migrations)
+- On quarterly schedule? (Q1, Q2, Q3, Q4)
+- After escalations? (decisions beyond scope)
+
+**Capture Methods:**
+- GitHub tracking issue (Release Manager model)
+- IMPLEMENTATION.md notes (AOT Guru model)
+- Automated prompts in skill (your choice)
+- Quarterly review meetings (maintainer involvement)
+
+**Example: Elm-to-F# Guru**
+```
+Capture Trigger: After each module migration
+Capture Method: Migration template includes "Patterns Discovered" section
+Review Schedule: Quarterly pattern inventory review
+Improvement Action: If pattern appears 3+ times, create Myriad plugin
+
+Q1: Discovered 15 new patterns
+Q2: Created 2 Myriad plugins for repetitive patterns
+Q3: Updated decision trees based on learnings
+Q4: Plan next quarter's automation
+```
+
+### Design Review Process
+
+Define quarterly reviews:
+
+1. **Collect:** Gather all feedback from past quarter
+2. **Analyze:** Identify 2-3 key improvements
+3. **Decide:** What will change? What won't?
+4. **Update:** Modify playbooks, templates, patterns
+5. **Document:** Record what changed and why
+6. **Communicate:** Let users know about improvements
+
+**Review Checklist:**
+- [ ] Feedback reviewed (N items)
+- [ ] Improvement areas identified (3-5 topics)
+- [ ] Playbooks updated (X changes)
+- [ ] Patterns added/modified (Y patterns)
+- [ ] Automation opportunities identified (Z scripts to create)
+- [ ] Version bumped if user-facing changes
+
+## Part 5B: Review Capability
+
+### Design the Review Scope
+
+A guru should proactively **review** its domain for issues, guideline violations, and improvement opportunities.
+
+**Define Review Scope Questions:**
+1. **What issues should this guru look for?**
+   - AOT Guru: Reflection usage, binary size creep, trimming-unfriendly patterns
+   - QA Tester: Coverage gaps, ignored tests, missing edge cases, guideline violations
+   - Release Manager: Process deviations, changelog quality, version inconsistencies
+   - Elm-to-F# Guru: Migration anti-patterns, Myriad plugin opportunities, F# idiom violations
+
+2. **How often should reviews run?**
+   - Continuous (real-time detection)
+   - Per-session (after each major workflow)
+   - Weekly (scheduled scan)
+   - Quarterly (comprehensive review)
+   - On-demand (user-triggered)
+
+3. **What triggers a review?**
+   - Code push? (CI/CD trigger)
+   - Release? (post-release verification)
+   - Schedule? (weekly, quarterly)
+   - Escalation? (manual request)
+
+4. **What's the output format?**
+   - Report document (Markdown table of findings)
+   - GitHub issues (one issue per finding)
+   - Notification (Slack, PR comment)
+   - Integrated summary (skill guidance update)
+
+5. **How do review findings feed back?**
+   - To playbooks: "We found 3 reflection patterns, add to decision tree"
+   - To automation: "This pattern appears repeatedly, create detection script"
+   - To retrospectives: "Q1 findings suggest process changes"
+   - To next review criteria: "Focus on this area going forward"
+
+### Create Review Scripts
+
+Design and implement F# scripts that perform reviews:
+
+**Example: AOT Guru's Quarterly Review**
+```fsharp
+// scripts/aot-scan.fsx - Quarterly review of all projects
+// Scans for:
+//   - Reflection usage (IL2026 patterns)
+//   - Binary sizes vs. targets
+//   - Trimming-unfriendly patterns (static fields, etc.)
+//
+// Output: Markdown report with findings, trends, recommendations
+
+Findings:
+- Reflection in 7 locations (5 in serialization, 2 in codegen)
+- Binary sizes: 8.2 MB (target 8 MB) - creeping by ~200 KB/quarter
+- New pattern: ValueTuple boxing in LINQ chains (appears 3x)
+- Opportunities: 2 patterns ready for Myriad plugin automation
+
+Recommendations:
+- Create aot-serializer.fsx (Myriad plugin) for serialization reflection
+- Add ValueTuple boxing detection to aot-diagnostics.fsx
+- Set size limit at 8.5 MB (buffer) or refactor
+
+Next Quarter Focus:
+- Monitor ValueTuple pattern frequency
+- Implement Myriad plugin if pattern appears >5 more times
+- Evaluate serialization library alternatives
+```
+
+### Integrate Review with Retrospectives
+
+Design how reviews and retrospectives work together:
+
+```
+Review (Proactive):
+  "I scanned the code and found these issues"
+  └─ Findings feed into retrospectives
+
+Retrospective (Reactive):
+  "That failure happened because of X"
+  └─ Root cause feeds into reviews: "Start looking for X pattern"
+
+Together: Continuous improvement cycle
+  Findings → Prevention → Process update → Review criteria → Next quarter
+```
+
+**Example Integration:**
+```
+Q1 Review Findings:
+- "We found 5 ignored tests. Why?"
+
+Q1 Retrospective:
+- "Test X was failing intermittently. We skipped it to unblock releases."
+
+Q1 Outcomes:
+- Fix root cause of flaky test
+- Add test to monitoring criteria
+- Playbook update: "Always investigate skipped tests in Q1 review"
+
+Q2 Review:
+- Monitors for skipped tests automatically
+- Finds 0 skipped tests (improvement!)
+- Pattern: "Skipped tests went from 5 → 0"
+```
+
+### Design Review Integration Points
+
+Define where reviews fit in the workflow:
+
+**Option A: Continuous Review**
+- Trigger: Every code push to main
+- Runs: During CI/CD
+- Output: GitHub check or PR comment
+- Effort: Medium (depends on scan speed)
+
+**Option B: Scheduled Review**
+- Trigger: Weekly or quarterly
+- Runs: Off-hours or on-demand
+- Output: Report + GitHub issues for findings
+- Effort: Low (scheduled, low impact)
+
+**Option C: Session-Based Review**
+- Trigger: After each major workflow (migration, release)
+- Runs: As part of workflow
+- Output: Integrated into workflow results
+- Effort: Varies (per-session analysis)
+
+**Option D: Manual Review**
+- Trigger: User request ("@guru review")
+- Runs: On-demand
+- Output: Full report generated immediately
+- Effort: Medium (real-time analysis)
+
+### Review Checklist
+
+When implementing review capability:
+
+- [ ] Review scope clearly defined (what issues to look for)
+- [ ] Review trigger designed (when does review run)
+- [ ] Review scripts created (F# implementation)
+- [ ] Review output format chosen (report/issues/notification)
+- [ ] Review findings documented (findings structure)
+- [ ] Integration with retrospectives designed
+- [ ] Integration with automation strategy designed
+- [ ] Integration with playbooks designed
+- [ ] Review schedule established (continuous/weekly/quarterly/on-demand)
+- [ ] Tested on real project data (not just examples)
+
+## Part 6: Cross-Agent Compatibility
+
+### Ensure Scripts Work Everywhere
+
+Your F# scripts should work for Claude Code, Copilot, and all other agents:
+
+**Checklist:**
+- [ ] Scripts use standard F# (no Claude-specific features)
+- [ ] Scripts have clear usage documentation
+- [ ] Scripts produce JSON output option (for parsing)
+- [ ] Scripts have exit codes (0 = success, 1 = validation failure, 2 = error)
+- [ ] Scripts document dependencies (required NuGet packages)
+- [ ] Scripts work on Windows, Mac, Linux
+
+### Document for All Agents
+
+Your README and documentation should explain:
+
+**For Claude Code users:**
+- How to invoke via @skill syntax
+- What YAML triggers work
+
+**For Copilot users:**
+- How to read .agents/ equivalent guides
+- How to run scripts directly
+
+**For other agents:**
+- How to find and copy this skill's README
+- How to run scripts directly
+
+**Example section:**
+```markdown
+## Using This Guru
+
+**Claude Code:** Mention keywords like "release", "deploy", "publish"
+**Copilot:** Read .agents/release-manager.md for equivalent guidance
+**Other agents:** Run scripts directly: `dotnet fsi scripts/monitor-release.fsx`
+```
+
+### Cross-Project Portability
+
+Document how this guru could be used in other projects:
+
+```markdown
+## Using This Guru in Other Projects
+
+### Portable Components
+- Decision trees (universal for this domain)
+- Pattern catalog (concepts apply broadly)
+- Script utilities (adapt paths for new project)
+
+### Non-Portable Components
+- Project-specific playbooks (morphir-dotnet release process)
+- Integration with NUKE build system
+- Version numbering conventions
+
+### To Adapt to New Project
+1. Update script paths (if paths differ)
+2. Update build system integration (if not NUKE)
+3. Adapt playbooks to new project's process
+4. Customize templates for new project conventions
+
+Estimated effort: 4-8 hours
+```
+
+## Part 7: Workflow & Validation
+
+### Red-Green-Refactor for Skill Development
+
+Follow TDD principles even for skills:
+
+**Red:** Write test scenarios for the skill
+- Create BDD features showing how the guru should behave
+- Create decision tree tests ("Given this scenario, recommend this")
+
+**Green:** Implement skill.md
+- Write guidance that makes tests pass
+- Create playbooks covering test scenarios
+
+**Refactor:** Improve skill based on feedback
+- Test with real scenarios
+- Get feedback from team
+- Update guidance and playbooks
+
+### BDD Scenarios for Skills
+
+Create `.feature` files demonstrating skill behavior:
+
+```gherkin
+Feature: Release Manager Guru
+
+  Scenario: Release fails and guru captures retrospective
+    Given a release is in progress
+    When the release fails
+    Then the guru should prompt for "What went wrong?"
+    And capture the response in the tracking issue
+    And suggest prevention strategies
+
+  Scenario: After 3 successful releases, guru prompts for improvements
+    Given 3 consecutive successful releases
+    When starting the 4th release
+    Then the guru should ask "What could we improve?"
+```
+
+### Testing Checklist
+
+Before releasing your guru:
+
+- [ ] Read through skill.md (is it clear? comprehensive?)
+- [ ] Test all automation scripts (do they work? return correct output?)
+- [ ] Validate decision trees (do they handle real scenarios?)
+- [ ] Check playbooks (are they complete? any steps missing?)
+- [ ] Review templates (are they usable? any clarifications needed?)
+- [ ] Test cross-agent compatibility (can Copilot users find equivalent info?)
+- [ ] Verify coordination (do other gurus know about this one?)
+- [ ] Get team feedback (does this feel useful? any blind spots?)
+
+## Part 8: Success Criteria
+
+### For Skill Delivery
+
+- [ ] Directory structure created
+- [ ] skill.md written (1000+ lines)
+- [ ] README.md created (300-400 lines)
+- [ ] MAINTENANCE.md documented
+- [ ] 3-5 automation scripts implemented
+- [ ] 5-10 seed patterns documented
+- [ ] 3-5 templates created
+- [ ] Coordination points identified
+- [ ] Cross-agent compatibility verified
+- [ ] Team feedback incorporated
+
+### For Skill Maturity (After First Quarter)
+
+- [ ] Feedback capture mechanism working
+- [ ] Quarterly review completed
+- [ ] 15+ patterns in catalog
+- [ ] 3+ improvements made based on feedback
+- [ ] 1+ new automation scripts created (if opportunities found)
+- [ ] Playbooks updated with learnings
+- [ ] Documentation updated
+- [ ] Version bumped (if user-facing changes)
+- [ ] Success metrics documented
+
+### For Skill Excellence (After Two Quarters)
+
+- [ ] 20+ patterns in catalog
+- [ ] 2+ custom Myriad plugins (if applicable)
+- [ ] Automated feedback mechanism working smoothly
+- [ ] Token efficiency analysis complete
+- [ ] Cross-project reuse strategy documented
+- [ ] Integration with other gurus proven
+- [ ] Continuous improvement cycle established
+- [ ] Learning system generating insights
+
+## Checklist: Creating a New Guru
+
+Use this checklist when creating a new guru:
+
+### Planning Phase
+- [ ] Domain clearly defined
+- [ ] 3+ competencies identified
+- [ ] Responsibilities documented
+- [ ] Scope boundaries explicit
+- [ ] Coordination points mapped
+- [ ] Feedback mechanism designed
+- [ ] Review schedule established
+
+### Implementation Phase
+- [ ] Directory structure created
+- [ ] skill.md written (1000+ lines)
+- [ ] README.md written (300-400 lines)
+- [ ] MAINTENANCE.md created
+- [ ] 3-5 automation scripts (high-token-cost tasks)
+- [ ] 5-10 seed patterns
+- [ ] 3-5 templates
+- [ ] Examples from real project
+
+### Validation Phase
+- [ ] Skill.md reviewed for clarity
+- [ ] Scripts tested (all work?)
+- [ ] Decision trees validated (real scenarios)
+- [ ] Playbooks verified (complete steps)
+- [ ] Templates usable (examples included)
+- [ ] Team feedback collected
+- [ ] Cross-agent compatibility checked
+- [ ] Coordination with other gurus verified
+
+### Launch Phase
+- [ ] Referenced in AGENTS.md
+- [ ] Added to .agents/skills-reference.md
+- [ ] Announcement to team
+- [ ] Integration guide created
+- [ ] First feedback collected
+- [ ] Initial learnings captured
+
+### Evolution Phase (After 1 Quarter)
+- [ ] Quarterly review completed
+- [ ] Feedback analyzed
+- [ ] 2-3 improvements made
+- [ ] Documentation updated
+- [ ] Version bumped
+- [ ] Team notified of improvements
+- [ ] Next quarter's improvements planned
+
+---
+
+**Last Updated:** December 19, 2025
+**Created By:** @DamianReeves
+**Version:** 1.0 (Initial Release)

--- a/docs/content/contributing/design/guru-philosophy.md
+++ b/docs/content/contributing/design/guru-philosophy.md
@@ -1,0 +1,433 @@
+---
+title: "Guru Philosophy"
+description: "The collaborative AI stewardship philosophy behind morphir-dotnet gurus"
+weight: 101
+---
+
+# Guru Philosophy
+
+## The Core Concept
+
+A **guru** is not a tool. It's not a utility function or a helpful prompt. A guru is a **knowledge stewardship system**—a specialized AI team member who owns a domain, improves continuously, and acts as a collaborative partner in advancing project health, maintainability, and velocity.
+
+This philosophy distinguishes morphir-dotnet's approach to AI collaboration from the typical "ask the AI for help with X" pattern.
+
+## The Guru is Not...
+
+### Not a Tool
+- ❌ Tools are static; gurus evolve
+- ❌ Tools answer one question; gurus build knowledge systems
+- ❌ Tools don't improve themselves; gurus have feedback loops
+- ✅ Gurus capture patterns and feed them back into guidance
+
+### Not a One-Off Helper
+- ❌ One-off helpers solve today's problem; gurus solve today's and tomorrow's
+- ❌ One-off helpers forget; gurus learn
+- ❌ One-off helpers don't coordinate; gurus collaborate
+- ✅ Gurus establish playbooks that improve with experience
+
+### Not a Replacement for Human Judgment
+- ❌ Gurus don't make decisions beyond their scope
+- ❌ Gurus don't override human preferences without explanation
+- ✅ Gurus escalate when uncertain
+- ✅ Gurus provide guidance and let humans decide
+
+## The Guru Is...
+
+### A Domain Steward
+A guru **owns** a specific area of the project:
+- **Quality Steward** (QA Tester) - Maintains testing standards and regression prevention
+- **Optimization Steward** (AOT Guru) - Guards trimming goals and AOT readiness
+- **Process Steward** (Release Manager) - Ensures releases are reliable and predictable
+- **Migration Steward** (Elm-to-F# Guru) - Preserves fidelity and quality in cross-language migration
+
+**What stewardship means:**
+- Accountable for quality in the domain
+- Proactive, not reactive ("What problems can I prevent?")
+- Maintains best practices and decision frameworks
+- Improves gradually, with intention
+
+### A Learning System
+A guru **improves over time** through automated feedback:
+
+**Release Manager Example (Proof):**
+- After every release failure → Automated retrospective captures "What went wrong?" and "How to prevent?"
+- After 3+ consecutive successes → Prompts for improvement ideas
+- When release procedures change → Detects and prompts playbook updates
+- Result: Release playbooks evolve each quarter, getting smarter
+
+**Elm-to-F# Guru Example (Planned):**
+- Every migration discovers new Elm-to-F# patterns
+- Patterns repeated 3+ times trigger "Create Myriad plugin?" decision
+- Quarterly reviews identify automation opportunities
+- Pattern catalog grows; decision trees improve
+
+**Key principle:** "Feedback is built in. Learning is automatic."
+
+### An Automation Specialist
+A guru **identifies high-token-cost repetitive work** and automates it:
+
+**Release Manager's `monitor-release.fsx`:**
+- Manual: Check GitHub Actions every few minutes (many tokens)
+- Automated: Script polls autonomously, reports status (few tokens)
+- Savings: 50-100 tokens per release
+- Over 20 releases/year: 1000-2000 tokens saved
+
+**QA Tester's `regression-test.fsx`:**
+- Manual: Run tests manually, interpret results (tokens)
+- Automated: Script runs full test suite, reports coverage (few tokens)
+- Savings: Medium tokens per session
+
+**AOT Guru's `aot-diagnostics.fsx`:**
+- Manual: Read IL warnings, categorize, suggest fixes (tokens)
+- Automated: Script parses logs, categorizes, suggests (few tokens)
+- Savings: Medium-high tokens per use
+
+**Philosophy:** "Every high-token task automated is a permanent improvement."
+
+### A Collaborator
+A guru **coordinates transparently** with other gurus:
+
+**Example: Elm-to-F# Migration**
+```
+Elm-to-F# Guru: "I'm generating AOT-compatible code"
+        ↓ (passes generated code to)
+   AOT Guru: "Verify this is AOT-safe"
+        ↓ (returns verdict + improvement suggestions)
+Elm-to-F# Guru: "Applied your recommendations"
+        ↓ (passes code to)
+   QA Tester: "Verify coverage >= 80%"
+        ↓ (returns test results)
+Release Manager: "Ready to include in release?"
+```
+
+**Collaboration principles:**
+- Explicit hand-offs at domain boundaries
+- Clear communication of status and constraints
+- Escalation paths when uncertain
+- Mutual respect for expertise
+
+### A Reviewer
+A guru **proactively reviews** the codebase and ecosystem for quality, adherence to principles, and opportunities:
+
+**Review Scope (Domain-Specific):**
+- **QA Tester** reviews: Test coverage, regression gaps, missing edge cases, BDD scenario compliance
+- **AOT Guru** reviews: Reflection usage, trimming-unfriendly patterns, AOT compatibility, binary size creep
+- **Release Manager** reviews: Release process adherence, changelog quality, version consistency, automation opportunities
+- **Elm-to-F# Guru** reviews: Migration patterns, Myriad plugin opportunities, F# idiom adherence, type safety
+
+**Review as Proactive Stewardship:**
+- Gurus don't wait to be asked; they scan for issues regularly
+- Review reports highlight problems AND suggest fixes
+- Reviews become input to retrospectives ("We found X issues this quarter")
+- Findings feed back into automation (e.g., "Reflection pattern appears 5 times → Create Myriad plugin")
+
+**Key difference from one-off code review:**
+- Code review is reactive: "Please review my PR"
+- Guru review is proactive: "I scanned the codebase and found these issues"
+- Code review gives feedback once
+- Guru review captures findings to improve guidance
+
+**Example: AOT Guru's Quarterly Review**
+```
+AOT Guru runs aot-scan.fsx quarterly against all projects:
+├── Detects reflection usage (IL2026 patterns)
+├── Measures binary sizes vs. targets
+├── Identifies new trimming-unfriendly patterns
+├── Documents findings in quarterly report
+└── Feeds findings into:
+    ├── Playbooks (e.g., "We found 3 new reflection anti-patterns")
+    ├── Decision trees (e.g., "When is Myriad worth it?")
+    ├── Automation (e.g., "Script now detects this pattern")
+    └── Next quarter's review criteria
+```
+
+**Integration with Retrospectives:**
+- Retrospectives answer: "What went wrong? How do we prevent it?"
+- Reviews answer: "What issues exist right now? What patterns are emerging?"
+- Together: Continuous improvement (see problems → fix them → prevent them → improve guidance)
+
+### A Teacher
+A guru **documents and preserves knowledge**:
+- Decision trees for problem-solving
+- Pattern catalog of domain-specific examples
+- Playbooks for complex workflows
+- Templates for common scenarios
+- "Why?" explanations, not just "What?"
+
+**Example: AOT Guru teaches**
+- "IL2026 warnings indicate reflection. Here's why that matters for AOT."
+- "Myriad can generate JSON codecs at compile-time. Here's when to use it."
+- "Source generators work differently than runtime reflection. Here's the trade-off."
+
+## The Guru Philosophy in Action
+
+### Release Manager: The Exemplar
+
+The Release Manager guru embodies the full philosophy:
+
+**Stewardship:**
+- Owns the release process and its reliability
+- Accountable for release quality and consistency
+- Proactively prevents failures
+
+**Learning:**
+- Captures failure retrospectives automatically
+- After 3 successes, prompts for improvements
+- Detects process changes and updates playbooks
+- Playbooks improve every quarter
+
+**Review:**
+- Quarterly review of all releases: Timing, success rate, common issues
+- Scans release artifacts for naming inconsistencies, changelog quality
+- Detects automation opportunities (e.g., "Failed at same step 3 times, automate this")
+- Report feeds into playbooks: "We saw X failure pattern, added prevention step"
+
+**Automation:**
+- `monitor-release.fsx` polls GitHub Actions autonomously
+- `prepare-release.fsx` validates pre-flight conditions
+- `validate-release.fsx` verifies post-release success
+- `resume-release.fsx` handles failure recovery
+- Total: 6 scripts handling routine release logistics
+
+**Collaboration:**
+- Coordinates with QA Tester for post-release verification
+- Coordinates with all gurus on version tagging
+- Clear escalation: Maintainer reviews if humans need to intervene
+
+**Teaching:**
+- Comprehensive playbooks for 4 release scenarios (standard, hotfix, pre-release, recovery)
+- Decision trees for version numbering
+- Templates for changelog management
+- Examples from actual releases
+
+### AOT Guru: Optimization Steward
+
+**Stewardship:**
+- Owns trimming and AOT readiness goals
+- Accountable for binary size targets (5-8 MB minimal)
+- Proactively identifies reflection usage
+
+**Learning:**
+- Catalogs new AOT incompatibilities discovered
+- Documents workarounds for common patterns
+- Quarterly reviews identify new optimization opportunities
+- Myriad plugin opportunities captured
+
+**Review:**
+- Quarterly scan of all projects for reflection patterns (IL2026)
+- Monitors binary sizes vs. targets, alerts on creep
+- Reviews generated code (Myriad plugins) for AOT safety
+- Detects new anti-patterns: "We found 5 reflection usages this quarter, suggest Myriad for X pattern"
+- Reports feed automation: "This pattern appears repeatedly, time to create automated detection"
+
+**Automation:**
+- `aot-diagnostics.fsx` analyzes projects for reflection
+- `aot-analyzer.fsx` parses build logs and categorizes IL warnings
+- `aot-test-runner.fsx` runs multi-platform test matrix
+- Token savings: Automatic analysis instead of manual review
+
+**Collaboration:**
+- Coordinates with QA Tester on AOT test runs
+- Coordinates with Elm-to-F# Guru on generated code safety
+- Escalates to maintainers for reflection decisions
+
+**Teaching:**
+- Decision trees: "I have an IL2026 warning. What should I do?"
+- Pattern catalog: Reflection anti-patterns and alternatives
+- Guides: Source generators vs. Myriad vs. manual
+
+### QA Tester: Quality Gate
+
+**Stewardship:**
+- Owns testing standards and coverage
+- Accountable for regression prevention
+- Proactively enforces ≥80% coverage
+
+**Learning:**
+- Discovers new edge cases in every migration
+- Test failures become regression test additions
+- Coverage trends tracked quarterly
+
+**Review:**
+- Continuous review of test coverage across all projects
+- Scans for ignored tests or skipped scenarios (why?)
+- Quarterly analysis: Coverage trends, gap patterns, edge cases discovered
+- Reviews BDD scenarios against guidelines: Are they comprehensive? Clear?
+- Identifies testing debt: "We've skipped this scenario 3 times, should we fix or remove it?"
+
+**Automation:**
+- `smoke-test.fsx` quick sanity check (~2 min)
+- `regression-test.fsx` full test suite (~10 min)
+- `validate-packages.fsx` NuGet package verification
+- Savings: Fast feedback loops, high confidence
+
+**Collaboration:**
+- Works with all gurus on testing their domain
+- Coordinates with Release Manager on pre-release verification
+- Clear standard: ≥80% coverage enforced
+
+**Teaching:**
+- BDD scenario templates
+- Test plan templates
+- Bug report templates
+- Coverage tracking guide
+
+## Building New Gurus
+
+### The Guru Creation Checklist
+
+When creating a new guru, embody these principles:
+
+1. **Stewardship**
+   - [ ] Clear domain ownership defined
+   - [ ] Responsibility boundaries explicit
+   - [ ] Accountability stated
+   - [ ] Quality/velocity/responsibility focus clear
+
+2. **Learning**
+   - [ ] Feedback mechanism designed (when/how to capture data)
+   - [ ] Review schedule established (quarterly? per-session?)
+   - [ ] Improvement loop designed (feedback → updates → publish)
+   - [ ] Knowledge base designed (catalog, templates, playbooks)
+
+3. **Review**
+   - [ ] Review scope clearly defined (what issues does this guru look for?)
+   - [ ] Review triggers established (continuous? scheduled? event-driven?)
+   - [ ] Review output designed (report format, findings categorization)
+   - [ ] Review findings fed to: Playbooks, automation, next review criteria
+   - [ ] Review integrated with retrospectives (findings → prevention → playbook updates)
+
+4. **Automation**
+   - [ ] High-token-cost tasks identified (3-5 candidates)
+   - [ ] F# scripts created for automation
+   - [ ] Token savings calculated
+   - [ ] Automation integrated into workflows
+
+5. **Collaboration**
+   - [ ] Coordination points with other gurus mapped
+   - [ ] Hand-off protocols designed
+   - [ ] Escalation paths explicit
+   - [ ] Error handling at boundaries
+
+5. **Collaboration**
+   - [ ] Coordination points with other gurus mapped
+   - [ ] Hand-off protocols designed
+   - [ ] Escalation paths explicit
+   - [ ] Error handling at boundaries
+
+6. **Teaching**
+   - [ ] Decision trees documented
+   - [ ] Pattern catalog designed
+   - [ ] Playbooks written
+   - [ ] Templates provided
+
+### The Guru Creation Phases
+
+**Phase 1: Definition**
+- Define domain and scope
+- Identify competencies (3-6 primary, 2-4 secondary)
+- Map coordination points
+- Design feedback mechanism
+
+**Phase 2: Implementation**
+- Write skill.md with comprehensive guidance
+- Create automation scripts (F# for high-token work)
+- Build pattern catalog
+- Design templates
+
+**Phase 3: Learning Integration**
+- Implement feedback capture
+- Establish review schedule
+- Design playbook evolution
+- Document improvement process
+
+**Phase 4: Review Implementation**
+- Design review scope and criteria
+- Create review scripts/tooling
+- Establish review schedule and cadence
+- Design integration with playbooks and automation
+
+**Phase 5: Collaboration**
+- Coordinate with other gurus
+- Test hand-offs
+- Verify escalation paths
+- Validate error handling
+
+**Phase 6: Teaching**
+- Create decision trees
+- Document patterns
+- Write playbooks
+- Provide templates
+
+## Guiding Principles
+
+### 1. Learn From Every Session
+
+> A guru that doesn't improve is just a prompt.
+
+Every session with a guru should feed insights back into its knowledge system. New patterns, edge cases, failures—all become part of the playbook.
+
+### 2. Review Proactively
+
+> A guru that only reacts to problems is incomplete.
+
+Gurus should scan their domain regularly for issues, guideline violations, and improvement opportunities. Reviews are how gurus stay engaged and make their presence felt. Combine review findings with retrospectives to create continuous improvement loops.
+
+**Review ≠ One-Off Code Review:**
+- Code review is reactive ("Please review my PR")
+- Guru review is proactive ("I scanned the project and found these issues")
+- Code review gives feedback once
+- Guru review captures findings to improve guidance
+
+### 3. Automate Repetitive Work
+
+> Token efficiency is a feature, not an afterthought.
+
+Identify high-token-cost repetitive work and create scripts to automate it. This makes the guru more efficient and the entire project benefit from permanent automation.
+
+### 4. Document Why, Not Just What
+
+> Teaching is as important as doing.
+
+When a guru provides guidance, it should explain the reasoning, not just the answer. This teaches users to make better decisions independently.
+
+### 5. Collaborate Transparently
+
+> Gurus are team members, not black boxes.
+
+Clear hand-offs, explicit coordination, and honest escalation build trust and effectiveness across the guru team.
+
+### 6. Respect Scope Boundaries
+
+> A guru should escalate gracefully when uncertain.
+
+Gurus should know their limits and escalate decisions beyond their scope. This prevents over-confident guidance in unfamiliar territory.
+
+### 7. Improve Continuously
+
+> Quarterly reviews are non-negotiable.
+
+Regular retrospectives, proactive reviews, feedback capture, and playbook updates ensure gurus don't ossify. A guru that never evolves is essentially deprecated.
+
+## The Vision
+
+Imagine a morphir-dotnet project where:
+
+- **Quality is maintained automatically** through QA Tester's standards
+- **AOT goals are pursued pragmatically** via AOT Guru's guidance
+- **Releases are reliable and predictable** thanks to Release Manager's playbooks
+- **Elm-to-F# migration proceeds smoothly** with Elm-to-F# Guru's expertise
+- **New domains are stewarded** by additional gurus built using proven patterns
+- **Every guru improves every quarter** through automated feedback
+- **Every guru automates high-token work** so humans focus on decisions
+- **Every guru collaborates gracefully** with clear hand-offs
+- **Knowledge is preserved and evolved** organically through use
+
+This is not a future state. It's what morphir-dotnet is building now.
+
+---
+
+**Last Updated:** December 19, 2025
+**Philosophy Champion:** @DamianReeves
+**Version:** 1.0 (Initial Documentation)

--- a/docs/content/contributing/design/skill-framework-design.md
+++ b/docs/content/contributing/design/skill-framework-design.md
@@ -1,0 +1,510 @@
+---
+title: "AI Skill Framework Design"
+description: "Design for unified, cross-agent AI skill architecture (gurus)"
+weight: 100
+---
+
+# AI Skill Framework Design
+
+## Overview
+
+This document establishes a comprehensive, scalable architecture for AI skills (known as "gurus" in this project) that work seamlessly across Claude Code, GitHub Copilot, and other coding agents. The goal is to create a repeatable pattern for developing specialized AI team members who improve continuously and provide expert guidance in specific domains.
+
+## Motivation
+
+The morphir-dotnet project has implemented three sophisticated gurus (QA Tester, AOT Guru, Release Manager) that provide specialized expertise through:
+- **Decision trees** for problem-solving
+- **Automation scripts** (F#) for repetitive tasks
+- **Playbooks** for complex workflows
+- **Templates** for common scenarios
+- **Pattern catalogs** of domain knowledge
+
+As the project plans to add more gurus (Elm-to-F# Guru, Documentation Guru, Security Guru, etc.), we need:
+1. A clear definition of what makes a guru
+2. Repeatable patterns for creation
+3. Cross-agent accessibility (not Claude-only)
+4. Continuous improvement mechanisms
+5. Cross-project reuse strategy
+
+## What is a Guru?
+
+A **guru** is not a tool or a prompt. It's a **knowledge stewardship system** with these characteristics:
+
+### Stewardship
+- **Owns a domain** (Quality, Optimization, Releases, Migration, etc.)
+- **Accountable** for quality, velocity, and responsibility in that domain
+- **Maintains and evolves** best practices and decision frameworks
+- **Acts as a quality gate** preventing regressions and anti-patterns
+
+### Continuous Improvement
+- **Learns from interactions** - Every session captures patterns and discoveries
+- **Feeds back into guidance** - Playbooks, templates, and catalogs evolve
+- **Automated feedback loops** (e.g., Release Manager retrospectives)
+- **Quarterly reviews** ensure knowledge remains current
+
+### Proactive Review
+- **Scans the domain regularly** for issues, violations, and improvement opportunities
+- **Detects problems before they escalate** - Review findings become preventative actions
+- **Captures patterns and trends** - Quarterly reviews identify what's working and what's not
+- **Feeds review findings into automation** - Patterns discovered 3+ times become scripts
+- **Combines with retrospectives** for continuous improvement: Find problems → Fix them → Prevent them → Improve guidance
+
+**Example:** AOT Guru's Quarterly Review
+- Scans all projects for reflection usage (IL2026 patterns)
+- Measures binary sizes vs. targets
+- Reports: "3 new reflection patterns, 1 binary growing too fast"
+- Actions: Update decision tree, create detection script, monitor closely
+
+### Automation-First
+- **Identifies high-token-cost tasks** - Repetitive diagnostics, testing, validation
+- **Creates F# scripts** to automate these patterns
+- **Reduces cognitive load** for future sessions
+- **Improves with scale** - Every use makes the system smarter
+
+### Collaboration
+- **Coordinates transparently** with other gurus
+- **Clear hand-offs** at domain boundaries
+- **Escalates decisions** beyond scope to maintainers
+- **Leverages shared patterns** from .agents/ guidance
+
+### Example: Release Manager
+The Release Manager guru exemplifies this philosophy:
+- **Stewardship:** Owns release lifecycle and process consistency
+- **Continuous Improvement:** Automated retrospective system captures feedback on failures/successes
+- **Automation:** `monitor-release.fsx` polls autonomously, saving tokens per release
+- **Collaboration:** Hands off to QA Tester for verification; coordinates with Elm-to-F# on version tracking
+
+## Architecture
+
+### Layer 1: Universal Guidance (All Agents)
+
+**Files:** `AGENTS.md`, `.agents/`
+
+This layer provides tool-agnostic guidance applicable to all agents:
+- Primary authority for coding standards, practices, philosophy
+- Decision frameworks and playbooks
+- Testing strategy, TDD workflow, quality standards
+- Morphir IR principles and modeling
+- Size: ~169 KB (AGENTS.md + 3 .agents/ guides)
+
+**Audience:** Claude Code, GitHub Copilot, Cursor, Windsurf, Aider, Neovim+Codeium, human developers
+
+### Layer 2: Agent-Specific Bridging
+
+**Files:** `copilot-instructions.md` (Copilot), `CLAUDE.md` (Claude Code)
+
+This layer provides agent-specific features and configuration:
+- How to access universal guidance in each agent
+- Agent-specific capabilities and limitations
+- Links to skills and automation scripts
+- Size: ~150 KB each (consolidated from 353 KB and 307 KB)
+
+**Audience:** Copilot users and Claude Code users respectively
+
+### Layer 3: Claude Code Enhancement
+
+**Files:** `.claude/skills/`
+
+This layer provides Claude-only specialization:
+- 3 stable gurus: QA Tester, AOT Guru, Release Manager
+- 1 planned: Elm-to-F# Guru
+- Accessible via `@skill {skill-name}` syntax
+- YAML metadata with trigger keywords
+- Size: ~220+ KB for 3 skills, framework designed to scale to 5-10+
+
+**Audience:** Claude Code users only
+
+**Gurus:**
+- **QA Tester** - Testing, validation, regression prevention (31 KB)
+- **AOT Guru** - Optimization, trimming, AOT readiness (220 KB)
+- **Release Manager** - Release lifecycle, deployment, recovery (104 KB)
+- **Elm-to-F# Guru** (planned) - Elm-to-F# migration, code generation (TBD)
+
+### Layer 4: Meta-Guidance (New)
+
+**Files:** `.agents/guru-philosophy.md`, `.agents/guru-creation-guide.md`, `.agents/skill-matrix.md`
+
+This layer guides the creation and evolution of gurus:
+- Guru philosophy and principles
+- Step-by-step creation guide
+- Maturity and coordination matrix
+- Success criteria and learning systems
+
+**Audience:** Future skill creators, maintainers, all agents
+
+## Skill Anatomy
+
+### Standard Components
+
+Each guru skill consists of:
+
+| Component | Purpose | Size | Audience |
+|-----------|---------|------|----------|
+| **skill.md** | Main persona, competencies, decision trees, playbooks | 1000-1200 lines (~50 KB) | Claude Code via @skill |
+| **README.md** | Quick start guide, use cases, script reference | 300-400 lines (~16 KB) | All agents (readable on GitHub) |
+| **Scripts/** | Diagnostic, testing, validation F# scripts | 3-5 scripts, 15-20 KB each | All agents (runnable via terminal) |
+| **Templates/** | Issue templates, test templates, workflow templates | Variable | All agents (reusable) |
+| **Patterns/** | Domain-specific pattern catalog | Cumulative | All agents (readable) |
+| **MAINTENANCE.md** | Quarterly review process, feedback capture | 1-2 KB | Maintainers, skill evolvers |
+
+### Token Budget
+
+**Per-Skill Target:** 50-100 KB
+- Preferred: 50-75 KB (efficient for context windows)
+- Acceptable: 75-100 KB (comprehensive domains)
+- Large: 100+ KB (complex domains, consider splitting)
+
+**Rationale:**
+- Claude Code has ~100K token context, can accommodate 200+ KB of skills
+- GitHub Copilot has ~8K tokens for instructions; scripts must be external
+- Other agents balance comprehensiveness with performance
+
+### Automation Scripts
+
+F# scripts should identify and automate high-token-cost repetitive work:
+
+**Examples:**
+- Release Manager's `monitor-release.fsx` - Autonomous workflow polling (saves tokens vs. manual polling)
+- QA Tester's `smoke-test.fsx` - Quick validation in ~2 minutes (fast feedback loop)
+- AOT Guru's `aot-diagnostics.fsx` - Automated problem analysis (reduces diagnostic overhead)
+
+**Savings Analysis:**
+- Diagnostic script that saves 100-200 tokens per use
+- If used 5 times per quarter: 500-1000 tokens saved per quarter
+- Over 1 year: 2000-4000 tokens saved
+- If skill is 50 KB (~8000 tokens), script pays for itself in 6-12 months
+
+## Guru Philosophy
+
+### Core Principles
+
+1. **Stewardship, Not Tooling**
+   - Gurus own domains, not just answer questions
+   - Improve with every interaction
+   - Accountable for quality in their area
+
+2. **Automate High-Token-Cost Work**
+   - Identify repetitive diagnostic/testing/validation tasks
+   - Create F# scripts to automate them
+   - Reduce cognitive load for future sessions
+
+3. **Learn from Every Interaction**
+   - Document new patterns discovered
+   - Update playbooks and catalogs
+   - Feed improvements back into guidance
+
+4. **Collaborate Transparently**
+   - Clear hand-offs to other gurus
+   - Explicit coordination points
+   - Escalate when beyond scope
+
+5. **Quality/Velocity/Responsibility Balance**
+   - Maintain or improve code quality
+   - Accelerate delivery through automation
+   - Take responsibility for domain health
+
+### Feedback Mechanisms
+
+**Release Manager (Exemplar):**
+- **Failure Retrospective:** When release fails, automatically prompt for feedback
+  - Captures: "What went wrong?" and "How to prevent?"
+  - Stores in tracking issue for pattern analysis
+- **Success Feedback:** After 3+ consecutive successes, prompt for improvements
+  - Captures: "What could we improve?" and "What automated?"
+  - Feeds into playbook refinements
+- **Process Change Detection:** When release procedures change, prompt for documentation updates
+
+**Elm-to-F# Guru (Planned):**
+- **Pattern Discovery:** Every migration discovers new Elm-to-F# patterns
+  - Adds to pattern catalog if novel
+  - Tags as "Myriad plugin candidate" if repetitive
+- **Quarterly Review:** Assess patterns, create Myriad plugins for repetitive cases
+  - Q1: Document new patterns
+  - Q2: Create Myriad plugins (1+ per quarter target)
+  - Q3: Update decision trees
+  - Q4: Plan next quarter
+
+**Template for New Gurus:**
+- Identify feedback triggers (when to capture data)
+- Define feedback storage (GitHub tracking issue, IMPLEMENTATION.md, etc.)
+- Establish review schedule (quarterly, per-session, after N uses)
+- Create improvement loop (feedback → updates → publish)
+
+## Cross-Agent Compatibility
+
+### Claude Code Users
+- **Access:** `@skill {skill-name}` syntax activates guru
+- **Context Window:** ~100K tokens, can load full skill.md + README.md + scripts overview
+- **Benefit:** Natural invocation, deep expertise, triggers via keywords
+- **Example:** User mentions "AOT warnings" → AOT Guru automatically invoked with decision trees
+
+### GitHub Copilot Users
+- **Access:** Read `.agents/` guides (universal guidance) + `.agents/skills-reference.md` (skill overview)
+- **Automation:** Run scripts via terminal: `dotnet fsi .claude/skills/{skill}/script.fsx`
+- **Context Window:** ~8K tokens for instructions; must reference external resources
+- **Benefit:** Same patterns and automation scripts, different discovery mechanism
+- **Example:** Copilot user reads `.agents/qa-testing.md` + runs `validate-packages.fsx` directly
+
+### Other Agents (Cursor, Windsurf, Aider, etc.)
+- **Access:** Read AGENTS.md and `.agents/` guides from GitHub
+- **Automation:** Execute F# scripts directly using `dotnet fsi`
+- **Context Window:** Varies (typically 4-20K for instructions)
+- **Benefit:** Universal guidance, portable scripts, no vendor lock-in
+- **Example:** Cursor user copies `.agents/aot-optimization.md` instructions into project context
+
+### Capabilities Matrix
+
+| Capability | Claude Code | Copilot | Cursor/Windsurf | Other Agents |
+|------------|:-----------:|:-------:|:---------------:|:------------:|
+| @skill syntax | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| YAML triggers | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| Read .agents/ | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Run F# scripts | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Decision trees | ✅ Full context | ⚠️ Manual reference | ✅ Yes | ✅ Yes |
+| Context budget | 100K+ | 8K | 4-20K | 4-20K |
+
+## Related Skills
+
+### Current Gurus
+
+**QA Tester**
+- **Domain:** Testing, validation, regression prevention
+- **Competencies:** Test planning, automation, coverage tracking, bug reporting
+- **Integration:** Coordinates with Release Manager for post-release verification
+- **Token Cost:** 31 KB (skill + scripts)
+- **Portability:** High (could apply to morphir-elm, morphir core)
+
+**AOT Guru**
+- **Domain:** Optimization, trimming, AOT readiness
+- **Competencies:** Diagnostics, size optimization, source generators, Myriad expertise
+- **Integration:** Coordinates with QA Tester for AOT-compatible test runs
+- **Token Cost:** 220 KB (skill + 3 diagnostic scripts)
+- **Portability:** High (portable if .NET versions of other projects emerge)
+
+**Release Manager**
+- **Domain:** Release lifecycle, deployment, recovery, process improvement
+- **Competencies:** Version management, changelog handling, deployment monitoring, retrospectives
+- **Integration:** Coordinates with QA Tester for post-release verification
+- **Token Cost:** 104 KB (skill + 6 automation scripts)
+- **Portability:** Medium (could adapt for mono-repo versioning)
+
+### Planned Guru
+
+**Elm-to-F# Guru** (#240)
+- **Domain:** Elm-to-F# migration, code generation, pattern discovery
+- **Competencies:** Language expertise, Myriad mastery, test extraction, compatibility verification
+- **Integration:** Coordinates with AOT Guru for AOT compatibility of generated code
+- **Token Cost:** TBD (target 50-100 KB)
+- **Portability:** Medium (patterns portable, IR-specific knowledge less so)
+
+### Future Candidates
+
+**Documentation Guru**
+- **Domain:** Documentation quality, API docs, examples
+- **Competencies:** Technical writing, markdown standards, doc generation, accessibility
+- **Integration:** Coordinates with Elm-to-F# for pattern documentation
+
+**Security Guru**
+- **Domain:** Security reviews, threat modeling, compliance
+- **Competencies:** Vulnerability scanning, OWASP standards, authorization patterns
+- **Integration:** Cross-cuts all gurus (every skill needs security review)
+
+**Performance Guru**
+- **Domain:** Benchmarking, profiling, optimization
+- **Competencies:** Performance testing, bottleneck identification, optimization strategies
+- **Integration:** Coordinates with AOT Guru on runtime performance
+
+## Token Efficiency Strategy
+
+### Problem
+GitHub Copilot instruction file is at practical size limit (~28 KB, 56% of available tokens). Cannot add more content without removing something.
+
+### Solution: Consolidation & Linking
+
+1. **Remove Duplication** (~50 KB savings)
+   - `copilot-instructions.md`: 353 → ~150 lines
+   - `CLAUDE.md`: 307 → ~150 lines
+   - Remove duplicated sections about TDD, conventions, Morphir modeling
+
+2. **Cross-Reference Instead of Duplicate**
+   - Copilot instructions → Link to AGENTS.md Section 9 (TDD)
+   - CLAUDE.md → Reference .agents/ guides instead of duplicating content
+   - Result: Free up 100-150 KB
+
+3. **Automation Over Explanation**
+   - High-token-cost work → F# scripts (Release Manager's polling script)
+   - Complex decisions → Guidance docs
+   - Result: Reduce explanation overhead
+
+4. **Semantic Linking** (Copilot)
+   - Include GitHub URLs to full guides
+   - Copilot users can follow links for comprehensive details
+   - Instructions remain under 8K tokens, full content accessible
+
+### Example: Release Manager
+
+**Before (Copilot):** Full playbooks (1200+ lines, 53 KB)
+- All release workflows documented in instructions
+- Exceeds Copilot token budget significantly
+- Difficult to maintain
+
+**After (Copilot):**
+- Overview in instructions (~500 lines, ~20 KB)
+- Link to `.claude/skills/release-manager/skill.md` for details
+- Link to `.agents/skills-reference.md#release-manager` for cross-agent access
+- `monitor-release.fsx` handles polling autonomously (reduces explanation)
+- Result: 60%+ token savings while maintaining capability
+
+### Savings Calculation
+
+```
+Release Manager Skill:
+- Playbook explanation: 1200 lines → 300 lines (75% reduction)
+- Reason: Automation handles complex logic (monitor-release.fsx)
+- Savings: 100-150 KB in copilot-instructions.md
+- Tradeoff: Users must read .agents/skills-reference.md for full playbooks
+- Benefit: Copilot users still get guidance, just discover it differently
+```
+
+## Cross-Project Reuse
+
+### Portability Strategy
+
+**Portable Skills:**
+- **QA Tester** → morphir-elm, morphir core (testing patterns apply universally)
+- **AOT Guru** → morphir-elm (if .NET port emerges)
+
+**Partially Portable:**
+- **Release Manager** → Could adapt for mono-repo versioning (CHANGELOG format may differ)
+- **Elm-to-F# Guru** → Pattern catalog portable, IR-specific knowledge less so
+
+### Reuse Checklist
+
+When planning to use a guru in a new project:
+
+- [ ] Understand skill's domain and scope
+- [ ] Assess project-specific config needs
+- [ ] Identify paths/repos that need adjustment
+- [ ] Read "Adapt to New Project" section in skill README
+- [ ] Test skill with sample scenario
+- [ ] Document adaptations (if any)
+- [ ] Report improvements back to origin project
+
+### Example: QA Tester in morphir-elm
+
+```
+Original (.morphir-dotnet): `.claude/skills/qa-tester/`
+├── skill.md - Core QA philosophy, no project-specific content
+├── README.md - Scripts references can be adapted
+└── scripts/
+    ├── smoke-test.fsx - Paths would need adjustment
+    ├── regression-test.fsx - Test command would change
+    └── validate-packages.fsx - Package names would differ
+
+Adapted (.morphir-elm):
+├── Test: npm run test vs. dotnet test
+├── Smoke: npm run build vs. dotnet build
+├── Packages: npm packages vs. NuGet packages
+├── Regression: Same BDD/TDD philosophy, different tech stack
+
+Effort: 2-4 hours to adapt and test
+```
+
+## Future Expansion
+
+### Roadmap
+
+**Phase 1 (Now):**
+- ✅ 3 stable gurus proven effective
+- ✅ Skill framework documented
+- 🚧 Cross-agent accessibility implemented
+- 🚧 Guru creation guide created
+
+**Phase 2 (Q1 2026):**
+- Elm-to-F# Guru implemented (#240)
+- Morphir.Internal.CodeGeneration created (#241)
+- Skills integrated with code generation
+- Quarterly review process established
+
+**Phase 3 (Q2-Q3 2026):**
+- Documentation Guru planned
+- Security Guru planned
+- First cross-project reuse (QA Tester → morphir-elm)
+- Skill marketplace envisioned
+
+**Phase 4 (Future):**
+- 5-10+ gurus actively maintained
+- Cross-project skill sharing established
+- Guru coordination at scale proven
+- Continuous improvement culture embedded
+
+### Scaling Considerations
+
+**Guru Coordination at Scale:**
+```
+Current (3 gurus):
+QA Tester ↔ Release Manager ↔ AOT Guru
+
+Future (7 gurus):
+Documentation ← Elm-to-F# → AOT → QA ↔ Release
+       ↓
+   Security (cross-cuts all)
+```
+
+**Dependency Management:**
+- Explicit coordination graph (who coordinates with whom)
+- Hand-off protocols at boundaries
+- Error handling for coordination failures
+- Token budgets account for coordination overhead
+
+**Feedback Loop Management:**
+- Each guru's retrospective/review process documented
+- Aggregated insights shared quarterly
+- Cross-guru learning captured (patterns that cross domains)
+
+## Success Criteria
+
+### For the Framework
+
+- [ ] Architecture document complete
+- [ ] GitHub issues created for implementation
+- [ ] Guru philosophy widely understood
+- [ ] Skill creation guide enables new gurus
+- [ ] 3 existing gurus assessed for alignment
+- [ ] Cross-agent accessibility proven
+- [ ] First new guru (Elm-to-F# #240) created using framework
+- [ ] Quarterly review process established and running
+- [ ] Token efficiency targets met (Copilot <30 KB)
+
+### For New Gurus
+
+- [ ] 3+ core competencies defined
+- [ ] 3-5 automation scripts created
+- [ ] 20+ patterns in catalog
+- [ ] Feedback mechanism implemented
+- [ ] Coordination points with other gurus explicit
+- [ ] Cross-project portability assessed
+- [ ] Quarterly review schedule established
+- [ ] Cross-agent compatibility documented
+
+## References
+
+- [AGENTS.md](../../../AGENTS.md) - Primary agent guidance
+- [CLAUDE.md](../../../CLAUDE.md) - Claude Code-specific guidance
+- [copilot-instructions.md](../../../.github/copilot-instructions.md) - Copilot configuration
+- [.agents/](../../../.agents/) - Specialized cross-agent guides
+- [.claude/skills/](../../../.claude/skills/) - Skill implementations
+
+## Related Issues
+
+- #253 - Design: Unified Cross-Agent AI Skill Framework Architecture
+- #254 - Implement: Cross-Agent Skill Accessibility & Consolidation
+- #255 - Implement: Guru Creation Guide & Skill Template
+- #240 - Create Elm to F# Guru Skill
+- #241 - Create Morphir.Internal.CodeGeneration Project
+
+---
+
+**Last Updated:** December 19, 2025
+**Maintained By:** @DamianReeves
+**Version:** 1.0 (Initial Release)


### PR DESCRIPTION
## Overview
Exposes the Contributing and Design documentation sections as top-level navigation items in the Hugo documentation site, making the AI Skill Framework and guru design documentation discoverable and navigable.

## Changes
- **Contributing** now appears as top-level nav menu (weight: 30)
- **Design** appears as hierarchical submenu under Contributing (weight: 10, parent: Contributing)
- Enhanced both _index.md files with comprehensive content and cross-references
- Added 3 new design documentation files:
  - `skill-framework-design.md` - Complete 4-layer architecture (510 lines)
  - `guru-philosophy.md` - Stewardship and review principles (433 lines)
  - `guru-creation-guide.md` - Step-by-step creation with Part 5B: Review Capability (877 lines)

## Files Changed
- `docs/content/contributing/_index.md` - Updated frontmatter (menu config, weight: 30), enhanced content
- `docs/content/contributing/design/_index.md` - Updated frontmatter (parent: Contributing, weight: 10), rewrote content
- `docs/content/contributing/design/skill-framework-design.md` - NEW (510 lines)
- `docs/content/contributing/design/guru-philosophy.md` - NEW (433 lines)
- `docs/content/contributing/design/guru-creation-guide.md` - NEW (877 lines)

## Statistics
- 5 files changed, 1913 insertions(+), 15 deletions(-)
- All pre-commit hooks passing ✅

## Related Issues
- Implements documentation exposure for #253, #254, #255, #256
- Provides foundation for implementing AI Skill Framework across all agents
- Enables review capability as first-class guru feature

## Testing
After merge, verify:
- Top-level nav shows "Contributing" menu item
- "Contributing" expands to show "Design" submenu
- All design documents are accessible and linkable
- Hugo build succeeds: `cd docs && npm run build`
- Site navigation works on both desktop and mobile