### PR TITLE
docs: add project board and issue creation guides

### DIFF
--- a/docs/content/contributing/design/implementation-plans/CREATE-PROJECT-BOARD.md
+++ b/docs/content/contributing/design/implementation-plans/CREATE-PROJECT-BOARD.md
@@ -1,0 +1,301 @@
+---
+title: "Create Project Board: Morphir Application Architect Skill"
+linkTitle: "Create Project Board"
+weight: 103
+description: >
+  Step-by-step guide to create and configure the GitHub Project board for tracking Morphir Application Architect skill implementation.
+---
+
+# Create Project Board for Morphir Application Architect Skill
+
+This guide walks through creating a GitHub Project board to track all 28 issues for the Morphir Application Architect skill.
+
+## Option 1: Automated Script (Recommended)
+
+### Prerequisites
+
+Your GitHub CLI token needs the `project` scope.
+
+**Add the scope**:
+```bash
+gh auth refresh -s project
+```
+
+### Run the Script
+
+```bash
+chmod +x scripts/create-project-board.sh
+./scripts/create-project-board.sh
+```
+
+The script will:
+1. Create a new project board
+2. Add all 28 issues (#314-341)
+3. Output the project URL
+
+---
+
+## Option 2: Manual Creation via Web UI
+
+If you prefer or if the script doesn't work, follow these steps:
+
+### Step 1: Create the Project
+
+1. Navigate to: https://github.com/orgs/finos/projects
+2. Click **"New project"**
+3. Choose **"Board"** template
+4. Name: `Morphir Application Architect Skill Implementation`
+5. Click **"Create project"**
+
+### Step 2: Configure Views
+
+#### Default Board View
+
+The default board view should have these columns:
+- **Backlog** - Issues not yet started
+- **In Progress** - Currently being worked on
+- **Review** - Awaiting review/approval
+- **Done** - Completed issues
+
+#### Add Status Field
+
+1. Click **"+"** to add a field
+2. Select **"Status"** (or create "Status" single-select field)
+3. Add options:
+   - ⏳ Backlog
+   - 🚧 In Progress
+   - 👀 Review
+   - ✅ Done
+
+#### Add Custom Fields (Optional but Recommended)
+
+**Phase Field** (Single Select):
+- Phase 1
+- Phase 2
+- Phase 3
+- Phase 4
+- Phase 4.5
+- Phase 5
+
+**Priority Field** (Single Select):
+- P0 (Critical)
+- P1 (High)
+- P2 (Medium)
+
+**Effort Field** (Number):
+- Unit: days
+
+### Step 3: Add Issues to Project
+
+#### Add Epic Issue
+
+1. In the project board, click **"+ Add item"**
+2. Search for `#314` (Epic: Morphir Application Architect Skill)
+3. Press Enter to add
+
+#### Bulk Add All Task Issues
+
+There are two ways to add the remaining 27 issues:
+
+**Method A: Add by Label Filter**
+
+1. Click **"+ Add item"**
+2. Type `label:skill:architect` in the search
+3. Select all issues that appear
+4. Add them to the project
+
+**Method B: Add Individually**
+
+Add each issue number manually:
+```
+#315, #316, #317, #318  (Phase 1)
+#319, #320, #321, #322, #323  (Phase 2)
+#324, #325, #326, #327, #328  (Phase 3)
+#329, #330, #331, #332  (Phase 4)
+#333, #334, #335  (Phase 4.5)
+#336, #337, #338, #339, #340, #341  (Phase 5)
+```
+
+### Step 4: Organize Issues
+
+#### Set Status for All Issues
+
+1. Select all issues (Ctrl+A or Cmd+A)
+2. Set Status to "Backlog"
+
+#### Group by Phase (Optional)
+
+1. Click **"Group"** dropdown
+2. Select **"Milestone"**
+3. Issues will be grouped by phase
+
+#### Sort by Issue Number
+
+1. Click **"Sort"** dropdown
+2. Select **"Issue number"** (ascending)
+3. Issues will be in order: #314-341
+
+### Step 5: Create Additional Views
+
+#### Create Table View
+
+1. Click **"+ New view"**
+2. Choose **"Table"**
+3. Name: `All Tasks`
+4. This view shows all fields in a spreadsheet format
+5. Useful for editing multiple fields at once
+
+#### Create Roadmap View
+
+1. Click **"+ New view"**
+2. Choose **"Roadmap"**
+3. Name: `Timeline`
+4. Set date field to milestone due dates
+5. Visualizes phases on a timeline
+
+#### Create Kanban per Phase
+
+For each phase, create a filtered view:
+
+1. Click **"+ New view"**
+2. Choose **"Board"**
+3. Name: `Phase 1 Tasks`
+4. Add filter: `milestone:"Phase 1: Core Architectural Guidance"`
+5. Repeat for Phases 2-5
+
+### Step 6: Configure Automation (Optional)
+
+GitHub Projects (beta) supports workflow automation:
+
+#### Auto-set Status on Issue Events
+
+1. Click **"..."** menu → **"Workflows"**
+2. Enable these automations:
+
+**Item added to project**:
+- Set Status to "Backlog"
+
+**Item closed**:
+- Set Status to "Done"
+
+**Pull request merged**:
+- Set Status to "Done"
+
+#### Custom Automations
+
+For more complex workflows, use GitHub Actions with the Projects API.
+
+Example: Auto-move to "In Progress" when assigned
+```yaml
+# .github/workflows/project-automation.yml
+name: Project Automation
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  move-to-in-progress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/finos/projects/YOUR_PROJECT_NUMBER
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          labeled: skill:architect
+
+      # Additional steps to update status field
+```
+
+### Step 7: Set Project Description and README
+
+1. Click **"..."** menu → **"Settings"**
+2. Add description:
+   ```
+   Tracking implementation of the Morphir Application Architect expert skill.
+
+   Epic: #314
+   PRD: See docs/content/contributing/design/prds/morphir-application-architect-skill.md
+   Total: 27 tasks across 5 phases (20 weeks)
+   ```
+
+3. Add project README (visible on project page):
+   ```markdown
+   # Morphir Application Architect Skill Implementation
+
+   Comprehensive expert skill combining:
+   - Morphir ecosystem mastery
+   - Language design expertise
+   - Functional programming patterns
+   - WebAssembly integration
+   - Semantic web technologies
+   - Integration protocols (gRPC, JSON-RPC, JSONL)
+
+   ## Quick Links
+   - [Epic #314](https://github.com/finos/morphir-dotnet/issues/314)
+   - [PRD](../docs/content/contributing/design/prds/morphir-application-architect-skill.md)
+   - [Implementation Plan](../docs/content/contributing/design/implementation-plans/morphir-architect-skill-plan.md)
+
+   ## Phases
+   - Phase 1: Core Architectural Guidance (4 tasks)
+   - Phase 2: Pluggable Pipeline Architecture (5 tasks)
+   - Phase 3: WebAssembly Integration (5 tasks)
+   - Phase 4: Semantic Web Integration (4 tasks)
+   - Phase 4.5: Integration Technologies (3 tasks)
+   - Phase 5: Integration and Documentation (6 tasks)
+   ```
+
+### Step 8: Share the Project
+
+1. Click **"..."** menu → **"Settings"**
+2. Set visibility to **"Public"** (or appropriate for your org)
+3. Get shareable link
+4. Add link to Epic issue (#314)
+
+## Verification Checklist
+
+After creating the project board, verify:
+
+- [ ] Project created with correct name
+- [ ] All 28 issues added (#314-341)
+- [ ] Board view configured with status columns
+- [ ] Custom fields added (Phase, Priority, Effort)
+- [ ] Issues set to "Backlog" status
+- [ ] Additional views created (Table, Roadmap)
+- [ ] Automation rules enabled
+- [ ] Project description and README set
+- [ ] Project visibility configured
+- [ ] Link added to Epic issue
+
+## Project Board URL
+
+After creation, the project URL will be:
+```
+https://github.com/orgs/finos/projects/YOUR_PROJECT_NUMBER
+```
+
+Add this URL to:
+- Epic issue #314 description
+- Repository README
+- This documentation
+
+## Maintenance
+
+**Weekly**:
+- Review and update issue statuses
+- Move completed issues to "Done"
+- Identify blocked issues
+
+**Monthly**:
+- Review milestone progress
+- Update phase completion percentages
+- Adjust timeline if needed
+
+**Per Phase**:
+- Close completed phase milestone
+- Open next phase for work
+- Conduct phase retrospective
+
+---
+
+**Questions?**: Tag `@maintainers` in Epic issue #314

--- a/docs/content/contributing/design/implementation-plans/ISSUE-CREATION-CHECKLIST.md
+++ b/docs/content/contributing/design/implementation-plans/ISSUE-CREATION-CHECKLIST.md
@@ -1,0 +1,356 @@
+---
+title: "Issue Creation Checklist: Morphir Application Architect Skill"
+linkTitle: "Issue Creation Checklist"
+weight: 102
+description: >
+  Step-by-step checklist for creating GitHub issues for the Morphir Application Architect skill implementation.
+---
+
+# Issue Creation Checklist: Morphir Application Architect Skill
+
+**Prerequisites**: PR #312 merged to main
+
+## Step 1: Create Labels
+
+Before creating issues, ensure these labels exist in the repository:
+
+```bash
+# Create labels using GitHub CLI
+gh label create "skill:architect" --description "Morphir Application Architect skill" --color "0E8A16"
+gh label create "phase-1" --description "Phase 1: Core Architectural Guidance" --color "D4C5F9"
+gh label create "phase-2" --description "Phase 2: Pluggable Pipeline Architecture" --color "C5DEF5"
+gh label create "phase-3" --description "Phase 3: WebAssembly Integration" --color "BFD4F2"
+gh label create "phase-4" --description "Phase 4: Semantic Web Integration" --color "C2E0C6"
+gh label create "phase-4.5" --description "Phase 4.5: Integration Technologies" --color "C2E0C6"
+gh label create "phase-5" --description "Phase 5: Integration and Documentation" --color "FAD8C7"
+gh label create "priority-p0" --description "Critical priority" --color "D73A4A"
+gh label create "priority-p1" --description "High priority" --color "FB8C00"
+gh label create "priority-p2" --description "Medium priority" --color "FEF2C0"
+```
+
+**Verification**:
+- [ ] All 11 labels created
+- [ ] Labels visible in repository settings
+
+## Step 2: Create Milestones
+
+Create milestones for each phase:
+
+```bash
+# Create milestones using GitHub CLI
+gh milestone create "Phase 1: Core Architectural Guidance" --due-date 2025-02-03 --description "Weeks 1-4: Ecosystem mastery, language patterns, FP patterns"
+gh milestone create "Phase 2: Pluggable Pipeline Architecture" --due-date 2025-03-03 --description "Weeks 5-8: Unified.js study, pipeline implementation, example plugins"
+gh milestone create "Phase 3: WebAssembly Integration" --due-date 2025-03-31 --description "Weeks 9-12: Component Model, WIT interfaces, Extism integration"
+gh milestone create "Phase 4: Semantic Web Integration" --due-date 2025-04-28 --description "Weeks 13-16: RDF schema, JSON-LD, linked data navigation"
+gh milestone create "Phase 5: Integration and Documentation" --due-date 2025-05-26 --description "Weeks 17-20: Cross-skill integration, pattern catalog, guides"
+```
+
+**Verification**:
+- [ ] All 5 milestones created
+- [ ] Due dates set correctly
+- [ ] Milestones visible in repository
+
+## Step 3: Create Epic Issue
+
+Create the epic issue first (it will serve as the parent for all task issues):
+
+**File to use**: `morphir-architect-github-issues.md` - Epic section
+
+**Command**:
+```bash
+# Extract epic issue body and create
+gh issue create \
+  --title "Epic: Morphir Application Architect Skill" \
+  --label "epic,skill:architect,enhancement" \
+  --assignee "@me"
+```
+
+Copy the epic issue markdown from the "Epic Issue" section in `morphir-architect-github-issues.md`.
+
+**Verification**:
+- [ ] Epic issue created
+- [ ] Labels applied correctly
+- [ ] Issue number noted for reference (will use to link task issues)
+
+**Note Epic Issue Number**: #____ (fill in after creation)
+
+## Step 4: Create Phase 1 Issues
+
+Create all Phase 1 task issues:
+
+### Issue 1.1: Morphir Ecosystem Documentation Review
+
+```bash
+gh issue create \
+  --title "Task 1.1: Morphir Ecosystem Documentation Review" \
+  --label "skill:architect,phase-1,priority-p0,documentation" \
+  --milestone "Phase 1: Core Architectural Guidance"
+```
+
+Copy body from "Issue 1.1" section in `morphir-architect-github-issues.md`.
+Update "Epic: #TBD" with actual epic issue number.
+
+**Verification**:
+- [ ] Issue 1.1 created
+- [ ] Labels applied
+- [ ] Milestone set
+- [ ] Epic reference updated
+
+### Issue 1.2: Language Design Pattern Research
+
+```bash
+gh issue create \
+  --title "Task 1.2: Language Design Pattern Research" \
+  --label "skill:architect,phase-1,priority-p0,research,patterns" \
+  --milestone "Phase 1: Core Architectural Guidance"
+```
+
+Copy body from "Issue 1.2" section.
+
+**Verification**:
+- [ ] Issue 1.2 created
+- [ ] Labels applied
+- [ ] Milestone set
+
+### Issue 1.3: Functional Programming Pattern Library
+
+```bash
+gh issue create \
+  --title "Task 1.3: Functional Programming Pattern Library" \
+  --label "skill:architect,phase-1,priority-p0,patterns,functional-programming" \
+  --milestone "Phase 1: Core Architectural Guidance"
+```
+
+Copy body from "Issue 1.3" section.
+
+**Verification**:
+- [ ] Issue 1.3 created
+- [ ] Labels applied
+- [ ] Milestone set
+
+### Issue 1.4: Create Initial Skill File
+
+```bash
+gh issue create \
+  --title "Task 1.4: Create Initial Skill File" \
+  --label "skill:architect,phase-1,priority-p0,documentation" \
+  --milestone "Phase 1: Core Architectural Guidance"
+```
+
+Copy body from "Issue 1.4" section.
+Update dependencies with actual issue numbers.
+
+**Verification**:
+- [ ] Issue 1.4 created
+- [ ] Labels applied
+- [ ] Milestone set
+- [ ] Dependencies updated
+
+## Step 5: Create Phase 2 Issues
+
+Follow the same pattern for Phase 2 (5 issues: 2.1 - 2.5):
+
+- [ ] Issue 2.1: Unified.js Architecture Study
+- [ ] Issue 2.2: Pipeline Architecture Design (ADR)
+- [ ] Issue 2.3: Implement Core Pipeline
+- [ ] Issue 2.4: Create Example Plugins
+- [ ] Issue 2.5: Pipeline Automation Scripts
+
+**Milestone**: Phase 2: Pluggable Pipeline Architecture
+
+## Step 6: Create Phase 3 Issues
+
+Create Phase 3 issues (5 issues: 3.1 - 3.5):
+
+- [ ] Issue 3.1: Component Model Deep Dive
+- [ ] Issue 3.2: Design WIT Interfaces for Morphir IR
+- [ ] Issue 3.3: Extism Integration Design
+- [ ] Issue 3.4: Cross-Runtime Communication Strategy
+- [ ] Issue 3.5: WebAssembly Automation Scripts
+
+**Milestone**: Phase 3: WebAssembly Integration
+
+## Step 7: Create Phase 4 and 4.5 Issues
+
+### Phase 4: Semantic Web Integration (4 issues: 4.1 - 4.4)
+
+- [ ] Issue 4.1: RDF Schema Design
+- [ ] Issue 4.2: JSON-LD Context Design
+- [ ] Issue 4.3: Linked Data Navigation Design
+- [ ] Issue 4.4: RDF Conversion Script
+
+**Milestone**: Phase 4: Semantic Web Integration
+
+### Phase 4.5: Integration Technologies (3 issues)
+
+**Note**: These are NEW issues not yet documented in the GitHub issues template. Create them manually:
+
+#### Issue 4.5.1: gRPC Integration Design
+
+```bash
+gh issue create \
+  --title "Task 4.5.1: gRPC Integration Design" \
+  --label "skill:architect,phase-4.5,priority-p1,grpc,integration" \
+  --milestone "Phase 4: Semantic Web Integration"
+```
+
+**Body**:
+```markdown
+## Task 4.5.1: gRPC Integration Design
+
+**Epic**: #XXX (Morphir Application Architect Skill)
+**Phase**: Phase 4.5
+**Labels**: `skill:architect`, `phase-4.5`, `priority-p1`, `grpc`, `integration`
+
+### Description
+Design gRPC service definitions for Morphir operations with Protocol Buffers.
+
+### Prerequisites
+- [ ] Phase 3 complete
+
+### Activities
+1. Design gRPC service definitions for Morphir operations
+2. Create Protocol Buffers (.proto) for IR types
+3. Support bidirectional streaming for transformations
+4. Enable service discovery and health checks
+
+### Deliverables
+- [ ] Proto definitions for core IR types
+- [ ] Service definitions for validation, optimization, generation
+- [ ] Streaming transformation support
+- [ ] gRPC-Web support for browser clients
+
+### Acceptance Criteria
+- [ ] Proto definitions for core IR types created
+- [ ] Service definitions working
+- [ ] Streaming transformation examples
+- [ ] gRPC-Web client tested
+
+### Effort Estimate
+2 days
+
+### Related Issues
+Part of Phase 4.5: Integration Technologies
+See PRD Section: Phase 4.5
+```
+
+- [ ] Issue 4.5.1 created
+
+#### Issue 4.5.2: JSON-RPC Integration Design
+
+Similar to above, with JSON-RPC specifics.
+
+- [ ] Issue 4.5.2 created
+
+#### Issue 4.5.3: JSON Lines Integration
+
+Similar to above, with JSONL specifics.
+
+- [ ] Issue 4.5.3 created
+
+## Step 8: Create Phase 5 Issues
+
+Create Phase 5 issues (6 issues: 5.1 - 5.6):
+
+- [ ] Issue 5.1: Cross-Skill Integration
+- [ ] Issue 5.2: Complete Pattern Catalog
+- [ ] Issue 5.3: Architecture Guides
+- [ ] Issue 5.4: Tutorial Series
+- [ ] Issue 5.5: Architecture Health Monitoring
+- [ ] Issue 5.6: Final Documentation Review
+
+**Milestone**: Phase 5: Integration and Documentation
+
+## Step 9: Create Project Board
+
+Set up GitHub Project board for tracking:
+
+```bash
+# Via GitHub UI (no CLI command for new Projects)
+1. Go to: https://github.com/finos/morphir-dotnet/projects
+2. Click "New project"
+3. Choose "Board" template
+4. Name: "Morphir Application Architect Skill Implementation"
+5. Add columns: Backlog, In Progress, Review, Done
+```
+
+**Verification**:
+- [ ] Project board created
+- [ ] Columns configured
+- [ ] All issues added to board (in Backlog)
+
+## Step 10: Update Epic Issue
+
+After all issues are created, update the Epic issue with actual issue numbers:
+
+**Update Epic issue body**:
+```markdown
+### Related Issues
+
+Phase 1: #XXX, #XXX, #XXX, #XXX
+Phase 2: #XXX, #XXX, #XXX, #XXX, #XXX
+Phase 3: #XXX, #XXX, #XXX, #XXX, #XXX
+Phase 4: #XXX, #XXX, #XXX, #XXX
+Phase 4.5: #XXX, #XXX, #XXX
+Phase 5: #XXX, #XXX, #XXX, #XXX, #XXX, #XXX
+```
+
+**Verification**:
+- [ ] Epic issue updated with all task issue numbers
+- [ ] All links work correctly
+
+## Step 11: Final Verification
+
+**Complete Checklist**:
+- [ ] All labels created (11 labels)
+- [ ] All milestones created (5 milestones)
+- [ ] Epic issue created and updated
+- [ ] All Phase 1 issues created (4 issues)
+- [ ] All Phase 2 issues created (5 issues)
+- [ ] All Phase 3 issues created (5 issues)
+- [ ] All Phase 4 issues created (4 issues)
+- [ ] All Phase 4.5 issues created (3 issues)
+- [ ] All Phase 5 issues created (6 issues)
+- [ ] **Total: 1 epic + 27 task issues = 28 issues**
+- [ ] Project board created and populated
+- [ ] All dependencies linked correctly
+- [ ] All issues have proper labels and milestones
+
+## Quick Commands Summary
+
+For rapid issue creation after labels/milestones are set up:
+
+```bash
+# Epic
+gh issue create --title "Epic: Morphir Application Architect Skill" \
+  --label "epic,skill:architect,enhancement"
+
+# Phase 1 (repeat for each issue with appropriate title/labels)
+gh issue create --title "Task 1.1: Morphir Ecosystem Documentation Review" \
+  --label "skill:architect,phase-1,priority-p0,documentation" \
+  --milestone "Phase 1: Core Architectural Guidance"
+
+# Use the morphir-architect-github-issues.md file for complete issue bodies
+```
+
+## Automation Script (Optional)
+
+For fully automated issue creation, create an F# script:
+
+**File**: `scripts/create-architect-issues.fsx`
+
+```fsharp
+#!/usr/bin/env dotnet fsi
+
+// Script to automate creation of all Morphir Architect issues
+// Usage: dotnet fsi scripts/create-architect-issues.fsx
+
+// TODO: Implement automated issue creation from template
+```
+
+---
+
+**Estimated Time**: 1-2 hours for manual creation
+**Recommended**: Create Epic and Phase 1 issues first, then iterate on subsequent phases as work progresses
+
+**Questions?**: Open an issue with label `maintainer-attention`

--- a/scripts/add-to-project-106.ps1
+++ b/scripts/add-to-project-106.ps1
@@ -1,0 +1,56 @@
+# PowerShell script to add all Morphir Architect issues to Project #106
+# Usage: .\scripts\add-to-project-106.ps1
+
+$PROJECT_ID = "PVT_kwDOAhvSls4AqfzK"
+$PROJECT_URL = "https://github.com/orgs/finos/projects/106"
+
+Write-Host "Adding issues #314-341 to project: $PROJECT_URL" -ForegroundColor Cyan
+Write-Host ""
+
+$successCount = 0
+$failCount = 0
+
+foreach ($issueNum in 314..341) {
+    Write-Host "Adding issue #$issueNum... " -NoNewline
+
+    # Get issue node ID
+    $issueQuery = @"
+{
+  "query": "query { repository(owner: \"finos\", name: \"morphir-dotnet\") { issue(number: $issueNum) { id } } }"
+}
+"@
+
+    try {
+        $issueResponse = gh api graphql -f query="query { repository(owner: \`"finos\`", name: \`"morphir-dotnet\`") { issue(number: $issueNum) { id } } }" | ConvertFrom-Json
+        $issueId = $issueResponse.data.repository.issue.id
+
+        if (-not $issueId) {
+            Write-Host "❌ Issue not found" -ForegroundColor Red
+            $failCount++
+            continue
+        }
+
+        # Add to project
+        $addMutation = "mutation { addProjectV2ItemById(input: { projectId: \`"$PROJECT_ID\`", contentId: \`"$issueId\`" }) { item { id } } }"
+        $addResponse = gh api graphql -f query=$addMutation 2>&1
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "✓" -ForegroundColor Green
+            $successCount++
+        }
+        else {
+            Write-Host "⚠️ (may already exist)" -ForegroundColor Yellow
+        }
+    }
+    catch {
+        Write-Host "❌ Error: $($_.Exception.Message)" -ForegroundColor Red
+        $failCount++
+    }
+}
+
+Write-Host ""
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "Complete! Successfully added $successCount issues" -ForegroundColor Green
+Write-Host "Failed/Skipped: $failCount issues" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "View project board at: $PROJECT_URL" -ForegroundColor Cyan

--- a/scripts/create-architect-issues.sh
+++ b/scripts/create-architect-issues.sh
@@ -1,0 +1,516 @@
+#!/usr/bin/env bash
+# Script to create all remaining Morphir Architect issues
+set -euo pipefail
+
+EPIC="#314"
+
+# Phase 2 Issues
+echo "Creating Phase 2 issues..."
+
+gh issue create --title "Task 2.1: Unified.js Architecture Study" \
+  --label "skill:architect,phase-2,priority-p0" \
+  --milestone "Phase 2: Pluggable Pipeline Architecture" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 2
+
+### Description
+Deep dive into unified.js architecture to understand pluggable transformation pipelines.
+
+### Activities
+1. Study unified.js source code
+2. Study unist specification
+3. Study vfile architecture
+4. Document key insights
+
+### Deliverables
+- [ ] Unified.js architecture analysis
+- [ ] Unist specification summary
+- [ ] VFile pattern analysis
+- [ ] Adaptation strategy for .NET/F#
+
+**Effort**: 2 days"
+
+gh issue create --title "Task 2.2: Pipeline Architecture Design (ADR)" \
+  --label "skill:architect,phase-2,priority-p0" \
+  --milestone "Phase 2: Pluggable Pipeline Architecture" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 2
+
+### Description
+Design pluggable pipeline architecture for Morphir IR transformations with ADR.
+
+### Activities
+1. Design processor architecture
+2. Design plugin interface
+3. Design metadata system
+4. Write ADR
+
+### Deliverables
+- [ ] ADR for pluggable pipeline
+- [ ] API design document
+- [ ] Interface definitions (F# and C#)
+- [ ] Architecture diagrams
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 2.3: Implement Core Pipeline" \
+  --label "skill:architect,phase-2,priority-p0" \
+  --milestone "Phase 2: Pluggable Pipeline Architecture" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 2
+
+### Description
+Implement the core pluggable pipeline architecture.
+
+### Activities
+1. Implement processor core
+2. Implement base plugin interfaces
+3. Implement metadata system
+4. Create unit tests
+
+### Deliverables
+- [ ] Processor.fs
+- [ ] Plugin.fs
+- [ ] Metadata.fs
+- [ ] Unit tests (>90% coverage)
+
+**Effort**: 5 days"
+
+gh issue create --title "Task 2.4: Create Example Plugins" \
+  --label "skill:architect,phase-2,priority-p1" \
+  --milestone "Phase 2: Pluggable Pipeline Architecture" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 2
+
+### Description
+Create example transformation plugins.
+
+### Activities
+1. Type validator plugin
+2. Optimization plugin
+3. Pretty printer plugin
+
+### Deliverables
+- [ ] Type validator plugin with tests
+- [ ] Optimization plugin with tests
+- [ ] Pretty printer plugin with tests
+- [ ] Plugin development guide
+
+**Effort**: 4 days"
+
+gh issue create --title "Task 2.5: Pipeline Automation Scripts" \
+  --label "skill:architect,phase-2,priority-p1" \
+  --milestone "Phase 2: Pluggable Pipeline Architecture" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 2
+
+### Description
+Create automation scripts for pipeline validation and performance.
+
+### Deliverables
+- [ ] validate-pipeline.fsx
+- [ ] analyze-pipeline-performance.fsx
+
+**Effort**: 2 days"
+
+# Phase 3 Issues
+echo "Creating Phase 3 issues..."
+
+gh issue create --title "Task 3.1: Component Model Deep Dive" \
+  --label "skill:architect,phase-3,priority-p0" \
+  --milestone "Phase 3: WebAssembly Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 3
+
+### Description
+Comprehensive study of WebAssembly Component Model, WIT, WAC.
+
+### Activities
+1. Study Component Model specification
+2. Study WIT
+3. Study WAC
+4. Document findings
+
+### Deliverables
+- [ ] Component Model study notes
+- [ ] WIT language reference
+- [ ] Canonical ABI mapping guide
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 3.2: Design WIT Interfaces for Morphir IR" \
+  --label "skill:architect,phase-3,priority-p0" \
+  --milestone "Phase 3: WebAssembly Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 3
+
+### Description
+Design WIT interfaces for Morphir IR.
+
+### Activities
+1. Design core IR types in WIT
+2. Design transformation interfaces
+3. Create example WIT files
+4. Write ADR
+
+### Deliverables
+- [ ] morphir-ir.wit
+- [ ] morphir-transform.wit
+- [ ] ADR for WIT design
+- [ ] Type mapping documentation
+
+**Effort**: 4 days"
+
+gh issue create --title "Task 3.3: Extism Integration Design" \
+  --label "skill:architect,phase-3,priority-p1" \
+  --milestone "Phase 3: WebAssembly Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 3
+
+### Description
+Design Extism plugin framework integration.
+
+### Activities
+1. Study Extism architecture
+2. Design Morphir plugin interface
+3. Create proof-of-concept (Rust)
+4. Document integration strategy
+
+### Deliverables
+- [ ] Extism integration design
+- [ ] Proof-of-concept Rust plugin
+- [ ] .NET host integration
+- [ ] Plugin development guide
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 3.4: Cross-Runtime Communication Strategy" \
+  --label "skill:architect,phase-3,priority-p1" \
+  --milestone "Phase 3: WebAssembly Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 3
+
+### Description
+Design cross-runtime communication (.NET ↔ WASM).
+
+### Activities
+1. Design IR serialization for WASM
+2. Design type marshalling
+3. Design async operation support
+4. Create benchmarks
+
+### Deliverables
+- [ ] Serialization format spec
+- [ ] Type marshalling guide
+- [ ] Async operation design
+- [ ] Performance benchmarks
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 3.5: WebAssembly Automation Scripts" \
+  --label "skill:architect,phase-3,priority-p2" \
+  --milestone "Phase 3: WebAssembly Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 3
+
+### Description
+Create WASM automation scripts.
+
+### Deliverables
+- [ ] generate-wit-interface.fsx
+- [ ] build-wasm-plugin.fsx
+
+**Effort**: 2 days"
+
+# Phase 4 Issues
+echo "Creating Phase 4 issues..."
+
+gh issue create --title "Task 4.1: RDF Schema Design" \
+  --label "skill:architect,phase-4,priority-p2" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4
+
+### Description
+Design RDF ontology for Morphir IR.
+
+### Activities
+1. Study existing ontologies
+2. Design Morphir IR ontology
+3. Create RDF schema
+4. Create examples
+
+### Deliverables
+- [ ] Morphir IR ontology (morphir.ttl)
+- [ ] Ontology documentation
+- [ ] Example RDF instances (10+)
+- [ ] SPARQL query examples
+
+**Effort**: 4 days"
+
+gh issue create --title "Task 4.2: JSON-LD Context Design" \
+  --label "skill:architect,phase-4,priority-p2" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4
+
+### Description
+Design JSON-LD context for Morphir IR.
+
+### Activities
+1. Design JSON-LD context
+2. Create context file
+3. Create examples
+4. Validate
+
+### Deliverables
+- [ ] morphir-context.jsonld
+- [ ] JSON-LD examples (10+)
+- [ ] Conversion guide
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 4.3: Linked Data Navigation Design" \
+  --label "skill:architect,phase-4,priority-p2" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4
+
+### Description
+Design linked data navigation system.
+
+### Activities
+1. Design URI scheme
+2. Design content negotiation
+3. Create navigation API
+4. Document patterns
+
+### Deliverables
+- [ ] URI scheme spec
+- [ ] Content negotiation design
+- [ ] Navigation API design
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 4.4: RDF Conversion Script" \
+  --label "skill:architect,phase-4,priority-p2" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4
+
+### Description
+Create RDF conversion automation.
+
+### Deliverables
+- [ ] rdf-converter.fsx
+- [ ] SPARQL query library (20+)
+- [ ] Conversion guide
+
+**Effort**: 3 days"
+
+# Phase 4.5 Issues (Integration Technologies)
+echo "Creating Phase 4.5 issues..."
+
+gh issue create --title "Task 4.5.1: gRPC Integration Design" \
+  --label "skill:architect,phase-4.5,priority-p1" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4.5
+
+### Description
+Design gRPC service definitions for Morphir operations.
+
+### Activities
+1. Design gRPC service definitions
+2. Create Protocol Buffers for IR types
+3. Support bidirectional streaming
+4. Enable service discovery
+
+### Deliverables
+- [ ] Proto definitions for IR types
+- [ ] Service definitions
+- [ ] Streaming support
+- [ ] gRPC-Web support
+
+**Effort**: 2 days"
+
+gh issue create --title "Task 4.5.2: JSON-RPC Integration Design" \
+  --label "skill:architect,phase-4.5,priority-p1" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4.5
+
+### Description
+Design JSON-RPC 2.0 API for Morphir operations.
+
+### Activities
+1. Design JSON-RPC API
+2. Support request/response and notifications
+3. Enable batch requests
+4. Provide WebSocket transport
+
+### Deliverables
+- [ ] JSON-RPC 2.0 spec
+- [ ] API documentation
+- [ ] Batch request support
+
+**Effort**: 2 days"
+
+gh issue create --title "Task 4.5.3: JSON Lines Integration" \
+  --label "skill:architect,phase-4.5,priority-p1" \
+  --milestone "Phase 4: Semantic Web Integration" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 4.5
+
+### Description
+Design JSON Lines streaming for IR data.
+
+### Activities
+1. Support JSONL format
+2. Enable pipeline chaining
+3. Design bulk transformation workflows
+4. Support progress reporting
+
+### Deliverables
+- [ ] JSONL parser/serializer
+- [ ] stdin/stdout pipeline support
+- [ ] Bulk transformation examples
+
+**Effort**: 2 days"
+
+# Phase 5 Issues
+echo "Creating Phase 5 issues..."
+
+gh issue create --title "Task 5.1: Cross-Skill Integration" \
+  --label "skill:architect,phase-5,priority-p0" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Create integration playbooks with other skills.
+
+### Activities
+1. Coordinate with aot-guru
+2. Coordinate with elm-to-fsharp-guru
+3. Coordinate with technical-writer
+4. Coordinate with qa-tester
+
+### Deliverables
+- [ ] Integration playbooks (4)
+- [ ] Cross-skill decision trees
+- [ ] Handoff protocols
+- [ ] Multi-skill workflows
+
+**Effort**: 4 days"
+
+gh issue create --title "Task 5.2: Complete Pattern Catalog" \
+  --label "skill:architect,phase-5,priority-p1" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Create comprehensive pattern catalog.
+
+### Activities
+1. Document 20+ patterns
+2. Create decision trees
+3. Provide code examples
+4. Document evolution
+
+### Deliverables
+- [ ] Pattern catalog (20+ patterns)
+- [ ] Decision trees (5+)
+- [ ] Code examples
+- [ ] Pattern evolution log
+
+**Effort**: 5 days"
+
+gh issue create --title "Task 5.3: Architecture Guides" \
+  --label "skill:architect,phase-5,priority-p1" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Create architecture guides.
+
+### Activities
+1. Write pluggable pipeline guide
+2. Write WASM integration guide
+3. Write semantic web guide
+4. Create diagrams
+
+### Deliverables
+- [ ] Pluggable pipeline guide
+- [ ] WASM integration guide
+- [ ] Semantic web guide
+- [ ] 10+ diagrams
+
+**Effort**: 4 days"
+
+gh issue create --title "Task 5.4: Tutorial Series" \
+  --label "skill:architect,phase-5,priority-p1" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Create tutorial series.
+
+### Deliverables
+- [ ] Tutorial 1: Transformation plugin
+- [ ] Tutorial 2: WASM generator
+- [ ] Tutorial 3: Semantic attribution
+- [ ] Tutorial code repositories
+
+**Effort**: 3 days"
+
+gh issue create --title "Task 5.5: Architecture Health Monitoring" \
+  --label "skill:architect,phase-5,priority-p1" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Create architecture health monitoring script.
+
+### Activities
+1. Create architecture-report.fsx
+2. Integrate with CI/CD
+3. Create health score dashboard
+
+### Deliverables
+- [ ] architecture-report.fsx
+- [ ] CI/CD integration
+- [ ] Health score metrics
+
+**Effort**: 2 days"
+
+gh issue create --title "Task 5.6: Final Documentation Review" \
+  --label "skill:architect,phase-5,priority-p0,documentation" \
+  --milestone "Phase 5: Integration and Documentation" \
+  --body "**Epic**: $EPIC
+**Phase**: Phase 5
+
+### Description
+Final documentation review.
+
+### Activities
+1. Review all skill documentation
+2. Ensure consistency
+3. Update cross-references
+4. Get technical-writer approval
+
+### Deliverables
+- [ ] Documentation review checklist
+- [ ] Cross-reference validation
+- [ ] Final approval
+
+**Effort**: 2 days"
+
+echo "All issues created successfully!"
+echo "Epic: #314"
+echo "Phase 1: #315, #316, #317, #318"
+echo "Phase 2-5: Check GitHub issues"

--- a/scripts/create-project-board.sh
+++ b/scripts/create-project-board.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Script to create GitHub Project board for Morphir Application Architect Skill
+#
+# PREREQUISITES:
+# Your GitHub token needs the 'project' scope.
+# Add it at: https://github.com/settings/tokens
+# Then run: gh auth refresh -s project
+#
+set -euo pipefail
+
+echo "Creating GitHub Project board..."
+
+# Get the organization/repository owner ID
+OWNER_ID=$(gh api graphql -f query='
+  query {
+    repository(owner: "finos", name: "morphir-dotnet") {
+      owner {
+        id
+      }
+    }
+  }
+' --jq '.data.repository.owner.id')
+
+echo "Owner ID: $OWNER_ID"
+
+# Create the project
+PROJECT_DATA=$(gh api graphql -f query='
+  mutation($ownerId: ID!) {
+    createProjectV2(input: {
+      ownerId: $ownerId
+      title: "Morphir Application Architect Skill Implementation"
+    }) {
+      projectV2 {
+        id
+        number
+        url
+      }
+    }
+  }
+' -f ownerId="$OWNER_ID")
+
+PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.createProjectV2.projectV2.id')
+PROJECT_URL=$(echo "$PROJECT_DATA" | jq -r '.data.createProjectV2.projectV2.url')
+
+echo "Project created: $PROJECT_URL"
+echo "Project ID: $PROJECT_ID"
+
+# Add all issues to the project (Epic #314 and tasks #315-341)
+echo "Adding issues to project..."
+
+for issue_num in {314..341}; do
+  echo "Adding issue #$issue_num..."
+
+  # Get issue node ID
+  ISSUE_ID=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+        }
+      }
+    }
+  ' -f owner="finos" -f repo="morphir-dotnet" -F number="$issue_num" --jq '.data.repository.issue.id')
+
+  # Add issue to project
+  gh api graphql -f query='
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {
+        projectId: $projectId
+        contentId: $contentId
+      }) {
+        item {
+          id
+        }
+      }
+    }
+  ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" > /dev/null
+
+  echo "  ✓ Added issue #$issue_num"
+done
+
+echo ""
+echo "✅ Project board created successfully!"
+echo "URL: $PROJECT_URL"
+echo ""
+echo "Next steps:"
+echo "1. Visit the project board"
+echo "2. Configure views (Board, Table, Roadmap)"
+echo "3. Add custom fields if needed (e.g., Phase, Effort)"
+echo "4. Set up automation rules"


### PR DESCRIPTION
## Overview

Follow-up to PR #312 - adds comprehensive guides and automation scripts for managing the Morphir Application Architect skill implementation.

## What's Added

### Documentation
- **CREATE-PROJECT-BOARD.md**: Complete guide for setting up GitHub Projects board
- **ISSUE-CREATION-CHECKLIST.md**: Step-by-step issue creation checklist

### Automation Scripts
- **add-to-project-106.ps1**: PowerShell script to add issues to existing project board
- **create-project-board.sh**: Bash script to create new project board (requires project scope)
- **create-architect-issues.sh**: Bash script to bulk create all task issues

## Status

- ✅ All 28 issues created (#314-341)
- ✅ All issues added to project board #106
- ✅ Epic, milestones, and labels configured
- ✅ Implementation ready to begin

## Related

- Epic: #314
- Original PRD PR: #312
- Project Board: https://github.com/orgs/finos/projects/106

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)