### PR TITLE
fix: Configure Copilot coding agent firewall to allow GitHub API access

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -147,6 +147,32 @@ public abstract record TypeExpr
 - Schemas in `docs/spec/schemas/` validated in CI
 - Backward compatibility: additive OK, breaking needs ADR
 
+## Copilot Coding Agent Firewall Configuration
+
+The Copilot coding agent runs with a firewall that limits internet access by default. This project is configured to allow access to the GitHub API for monitoring CI/CD workflow status.
+
+**Configuration File**: [`.github/workflows/copilot-setup-steps.yml`](./workflows/copilot-setup-steps.yml)
+
+This file:
+- Sets `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS` to include `api.github.com`
+- Configures .NET SDK for the development environment
+- Runs before the firewall is enabled
+
+**Troubleshooting Firewall Issues**:
+
+If you see a warning like:
+> Firewall rules blocked me from connecting to one or more addresses
+
+Options to resolve:
+1. **Add to custom allowlist** (admin-only): Settings → Copilot → coding agent → Custom allowlist
+2. **Update copilot-setup-steps.yml**: Add the blocked domain to `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS`
+3. **Use setup steps**: Run network calls in the `copilot-setup-steps` job before the firewall activates
+
+**Documentation**:
+- [Customizing the firewall](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-firewall)
+- [Copilot allowlist reference](https://docs.github.com/en/copilot/reference/copilot-allowlist-reference)
+- [Customizing the development environment](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent)
+
 ## Additional Resources
 
 **Essential Reading**:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,34 @@
+# GitHub Copilot Coding Agent Setup Steps
+# This workflow configures the environment for the Copilot coding agent.
+# It runs before the agent starts working and before the firewall is enabled.
+#
+# Documentation: https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent
+
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+env:
+  # Allow Copilot to access GitHub API for workflow status checks
+  # This enables the agent to monitor CI/CD pipeline status
+  # See: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-firewall
+  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: api.github.com
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Install .NET SDK for morphir-dotnet development
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      # Restore global tools that may be needed
+      - name: Restore .NET tools
+        run: |
+          echo "Environment configured for morphir-dotnet development"
+          echo ".NET SDK version: $(dotnet --version)"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/copilot-setup-steps.yml` with firewall configuration to allow `api.github.com` access
- Update `.github/copilot-instructions.md` with firewall troubleshooting documentation

This enables the Copilot coding agent to monitor CI/CD workflow status when working on PRs, fixing the "Firewall rules blocked me from connecting" warning seen in PR #373.

## Test plan

- [ ] Verify copilot-setup-steps.yml workflow is valid YAML
- [ ] Confirm firewall environment variable is correctly set
- [ ] Test that Copilot coding agent can access GitHub API on next PR interaction

## References

- [Customizing the agent firewall](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-firewall)
- [Customizing the development environment](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)